### PR TITLE
Important: Fix: Guest Captcha is not checked in Wordpress-Comments

### DIFF
--- a/friendly-captcha/modules/wordpress/wordpress_comments.php
+++ b/friendly-captcha/modules/wordpress/wordpress_comments.php
@@ -53,7 +53,7 @@ function frcaptcha_wp_comments_validate($comment) {
         return $comment;
     }
     // Non-Guest user
-    else if (!$plugin->get_wp_comments_logged_in_active()) {
+    else if ($comment["user_id"] != 0 && !$plugin->get_wp_comments_logged_in_active()) {
         return $comment;
     }
 


### PR DESCRIPTION
If the Captcha is only enabled for guests but not for logged-in-users, the guests can post SPAM without any serverside validation.

Steps to reproduce:

* ReCaptcha Settings like this: ![ksnip_tmp_YVciRU](https://user-images.githubusercontent.com/1087128/137590008-37bb589d-1b3d-45e5-9f27-8d7536894b7e.png)
* Open the comment page of a post
* Wait for the captcha to be solved
* Remove the hidden frc-captcha-solution field (or only value) from the form via browser dev-tools to simulate an unsolved captcha
* Submit the comment form
* **What I see**: Comment is accepted for moderation
* **What I expect**: Captcha verification failure

This pull request fixes this important issue.

I was thinking at first, that Friendly Captcha is just not efficient enough or I get manually submitted SPAM - but the real reason seems to be this bug.

