### PR TITLE
Add WooCommerce support

### DIFF
--- a/friendly-captcha/includes/core.php
+++ b/friendly-captcha/includes/core.php
@@ -31,6 +31,11 @@
         public static $option_wp_reset_password_integration_active_name = "frcaptcha_wp_reset_password_integration_active";
         public static $option_wp_comments_integration_active_name = "frcaptcha_wp_comments_integration_active";
         public static $option_wp_comments_logged_in_integration_active_name = "frcaptcha_wp_comments_logged_in_integration_active";
+
+        public static $option_wc_register_integration_active_name = "frcaptcha_wc_register_integration_active";
+        public static $option_wc_login_integration_active_name = "frcaptcha_wc_login_integration_active";
+        public static $option_wc_lost_password_integration_active_name = "frcaptcha_wc_lost_password_integration_active";
+        public static $option_wc_checkout_integration_active_name = "frcaptcha_wc_checkout_integration_active";
         
 
         public static $option_widget_language_name = "frcaptcha_widget_language";
@@ -109,6 +114,22 @@
             return get_option(FriendlyCaptcha_Plugin::$option_wp_comments_logged_in_integration_active_name) == 1;
         }
 
+        public function get_wc_login_active() {
+            return get_option(FriendlyCaptcha_Plugin::$option_wc_login_integration_active_name) == 1;
+        }
+
+        public function get_wc_register_active() {
+            return get_option(FriendlyCaptcha_Plugin::$option_wc_register_integration_active_name) == 1;
+        }
+
+        public function get_wc_lost_password_active() {
+            return get_option(FriendlyCaptcha_Plugin::$option_wc_lost_password_integration_active_name) == 1;
+        }
+
+        public function get_wc_checkout_active() {
+            return get_option(FriendlyCaptcha_Plugin::$option_wc_checkout_integration_active_name) == 1;
+        }
+
         /* Widget options */
 
         public function get_widget_language() {
@@ -181,5 +202,21 @@
 
     if (FriendlyCaptcha_Plugin::$instance->get_wp_comments_active()) {
         require plugin_dir_path( __FILE__ ) . '../modules/wordpress/wordpress_comments.php';
+    }
+
+    if (FriendlyCaptcha_Plugin::$instance->get_wc_login_active()) {
+        require plugin_dir_path( __FILE__ ) . '../modules/woocommerce/woocommerce_login.php';
+    }
+
+    if (FriendlyCaptcha_Plugin::$instance->get_wc_register_active()) {
+        require plugin_dir_path( __FILE__ ) . '../modules/woocommerce/woocommerce_register.php';
+    }
+
+    if (FriendlyCaptcha_Plugin::$instance->get_wc_lost_password_active()) {
+        require plugin_dir_path( __FILE__ ) . '../modules/woocommerce/woocommerce_lost_password.php';
+    }
+
+    if (FriendlyCaptcha_Plugin::$instance->get_wc_checkout_active()) {
+        require plugin_dir_path( __FILE__ ) . '../modules/woocommerce/woocommerce_checkout.php';
     }
 // }

--- a/friendly-captcha/includes/settings.php
+++ b/friendly-captcha/includes/settings.php
@@ -51,6 +51,22 @@ if (is_admin()) {
             FriendlyCaptcha_Plugin::$option_group,
             FriendlyCaptcha_Plugin::$option_wp_comments_logged_in_integration_active_name
         );
+        register_setting(
+            FriendlyCaptcha_Plugin::$option_group,
+            FriendlyCaptcha_Plugin::$option_wc_register_integration_active_name
+        );
+        register_setting(
+            FriendlyCaptcha_Plugin::$option_group,
+            FriendlyCaptcha_Plugin::$option_wc_login_integration_active_name
+        );
+        register_setting(
+            FriendlyCaptcha_Plugin::$option_group,
+            FriendlyCaptcha_Plugin::$option_wc_lost_password_integration_active_name
+        );
+        register_setting(
+            FriendlyCaptcha_Plugin::$option_group,
+            FriendlyCaptcha_Plugin::$option_wc_checkout_integration_active_name
+        );
 
         /*Widget settings */
         register_setting(
@@ -220,6 +236,54 @@ if (is_admin()) {
             array(
                 "option_name" => FriendlyCaptcha_Plugin::$option_wp_comments_logged_in_integration_active_name,
                 "description" => "Enable Friendly Captcha for WordPress Comments for users that are logged in to Wordpress.",
+                "type" => "checkbox"
+            )
+        );
+
+        add_settings_field(
+            'frcaptcha_settings_wc_register_integration_field',
+            'WooCommerce Register', 'frcaptcha_settings_field_callback',
+            'friendly_captcha_admin',
+            'frcaptcha_integrations_settings_section',
+            array(
+                "option_name" => FriendlyCaptcha_Plugin::$option_wc_register_integration_active_name,
+                "description" => "Enable Friendly Captcha for the WooCommerce sign up form.",
+                "type" => "checkbox"
+            )
+        );
+
+        add_settings_field(
+            'frcaptcha_settings_wc_login_integration_field',
+            'WooCommerce Login', 'frcaptcha_settings_field_callback',
+            'friendly_captcha_admin',
+            'frcaptcha_integrations_settings_section',
+            array(
+                "option_name" => FriendlyCaptcha_Plugin::$option_wc_login_integration_active_name,
+                "description" => "Enable Friendly Captcha for the WooCommerce log in form.",
+                "type" => "checkbox"
+            )
+        );
+
+        add_settings_field(
+            'frcaptcha_settings_wc_lost_password_integration_field',
+            'WooCommerce Lost Password', 'frcaptcha_settings_field_callback',
+            'friendly_captcha_admin',
+            'frcaptcha_integrations_settings_section',
+            array(
+                "option_name" => FriendlyCaptcha_Plugin::$option_wc_lost_password_integration_active_name,
+                "description" => "Enable Friendly Captcha for the WooCommerce lost password form.",
+                "type" => "checkbox"
+            )
+        );
+
+        add_settings_field(
+            'frcaptcha_settings_wc_checkout_integration_field',
+            'WooCommerce Checkout', 'frcaptcha_settings_field_callback',
+            'friendly_captcha_admin',
+            'frcaptcha_integrations_settings_section',
+            array(
+                "option_name" => FriendlyCaptcha_Plugin::$option_wc_checkout_integration_active_name,
+                "description" => "Enable Friendly Captcha for the WooCommerce checkout form.",
                 "type" => "checkbox"
             )
         );

--- a/friendly-captcha/modules/woocommerce/index.php
+++ b/friendly-captcha/modules/woocommerce/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/friendly-captcha/modules/woocommerce/woocommerce_checkout.php
+++ b/friendly-captcha/modules/woocommerce/woocommerce_checkout.php
@@ -1,0 +1,46 @@
+<?php
+
+add_action( 'woocommerce_after_checkout_billing_form', 'frcaptcha_wc_checkout_show_widget', 10, 0 );
+
+function frcaptcha_wc_checkout_show_widget() {
+    $plugin = FriendlyCaptcha_Plugin::$instance;
+    if (!$plugin->is_configured() or !$plugin->get_wc_checkout_active()) {
+        return;
+    }
+
+    echo frcaptcha_generate_widget_tag_from_plugin($plugin);
+
+    // it just slightly overflows..
+    echo '<style>.frc-captcha {max-width:100%; margin-bottom: 1em}</style>';
+
+    frcaptcha_enqueue_widget_scripts();
+}
+
+add_action( 'woocommerce_checkout_process', 'frcaptcha_wc_checkout_validate', 20, 3 );	
+
+function frcaptcha_wc_checkout_validate() {
+
+    if ( empty( $_POST ) ) {
+        return;
+    }
+
+    $plugin = FriendlyCaptcha_Plugin::$instance;
+    if (!$plugin->is_configured() or !$plugin->get_wc_checkout_active()) {
+        return;
+    }
+
+    $errorPrefix = '<strong>' . __( 'Error', 'wp-captcha' ) . '</strong> : ';
+	$solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
+	
+	if ( empty( $solution ) ) {
+        $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message() . __(' (captcha missing)', 'frcaptcha');
+        wc_add_notice( $error_message, 'error' );
+    }
+
+    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+
+    if (!$verification['success']) {
+        $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message();
+        wc_add_notice( $error_message, 'error' );
+    }
+}

--- a/friendly-captcha/modules/woocommerce/woocommerce_checkout.php
+++ b/friendly-captcha/modules/woocommerce/woocommerce_checkout.php
@@ -29,7 +29,7 @@ function frcaptcha_wc_checkout_validate() {
         return;
     }
 
-    $errorPrefix = '<strong>' . __( 'Error', 'wp-captcha' ) . '</strong> : ';
+    $errorPrefix = '<strong>' . __( 'Error', 'frcaptcha' ) . '</strong> : ';
 	$solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
 	
 	if ( empty( $solution ) ) {

--- a/friendly-captcha/modules/woocommerce/woocommerce_login.php
+++ b/friendly-captcha/modules/woocommerce/woocommerce_login.php
@@ -1,0 +1,48 @@
+<?php
+
+add_action( 'woocommerce_login_form', 'frcaptcha_wc_login_show_widget', 10, 0 );
+
+function frcaptcha_wc_login_show_widget() {
+    $plugin = FriendlyCaptcha_Plugin::$instance;
+    if (!$plugin->is_configured() or !$plugin->get_wc_login_active()) {
+        return;
+    }
+
+    echo frcaptcha_generate_widget_tag_from_plugin($plugin);
+
+    // it just slightly overflows..
+    echo '<style>.frc-captcha {max-width:100%; margin-bottom: 1em}</style>';
+
+    frcaptcha_enqueue_widget_scripts();
+}
+
+add_action( 'woocommerce_process_login_errors', 'frcaptcha_wc_login_validate', 20, 3 );	
+
+function frcaptcha_wc_login_validate($validation_error) {
+
+    if ( empty( $_POST ) ) {
+        return;
+    }
+
+    $plugin = FriendlyCaptcha_Plugin::$instance;
+    if (!$plugin->is_configured() or !$plugin->get_wc_login_active()) {
+        return;
+    }
+
+    $errorPrefix = '<strong>' . __( 'Error', 'wp-captcha' ) . '</strong> : ';
+	$solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
+	
+	if ( empty( $solution ) ) {
+        $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message() . __(' (captcha missing)', 'frcaptcha');
+        $validation_error->add( 'frcaptcha-empty-error', $error_message );
+    }
+
+    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+
+    if (!$verification['success']) {
+        $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message();
+        $validation_error->add( 'frcaptcha-solution-error', $error_message );
+    }
+
+    return $validation_error;
+}

--- a/friendly-captcha/modules/woocommerce/woocommerce_lost_password.php
+++ b/friendly-captcha/modules/woocommerce/woocommerce_lost_password.php
@@ -1,0 +1,17 @@
+<?php
+
+add_action( 'woocommerce_lostpassword_form', 'frcaptcha_wc_lost_password_show_widget', 10, 0 );
+
+function frcaptcha_wc_lost_password_show_widget() {
+    $plugin = FriendlyCaptcha_Plugin::$instance;
+    if (!$plugin->is_configured() or !$plugin->get_wc_lost_password_active()) {
+        return;
+    }
+
+    echo frcaptcha_generate_widget_tag_from_plugin($plugin);
+
+    // it just slightly overflows..
+    echo '<style>.frc-captcha {max-width:100%; margin-bottom: 1em}</style>';
+
+    frcaptcha_enqueue_widget_scripts();
+}

--- a/friendly-captcha/modules/woocommerce/woocommerce_register.php
+++ b/friendly-captcha/modules/woocommerce/woocommerce_register.php
@@ -29,7 +29,7 @@ function frcaptcha_wc_register_validate($validation_error) {
         return;
     }
 
-    $errorPrefix = '<strong>' . __( 'Error', 'wp-captcha' ) . '</strong> : ';
+    $errorPrefix = '<strong>' . __( 'Error', 'frcaptcha' ) . '</strong> : ';
 	$solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
 	
 	if ( empty( $solution ) ) {

--- a/friendly-captcha/modules/woocommerce/woocommerce_register.php
+++ b/friendly-captcha/modules/woocommerce/woocommerce_register.php
@@ -1,0 +1,48 @@
+<?php
+
+add_action( 'woocommerce_register_form', 'frcaptcha_wc_register_show_widget', 10, 0 );
+
+function frcaptcha_wc_register_show_widget() {
+    $plugin = FriendlyCaptcha_Plugin::$instance;
+    if (!$plugin->is_configured() or !$plugin->get_wc_register_active()) {
+        return;
+    }
+
+    echo frcaptcha_generate_widget_tag_from_plugin($plugin);
+
+    // it just slightly overflows..
+    echo '<style>.frc-captcha {max-width:100%; margin-bottom: 1em}</style>';
+
+    frcaptcha_enqueue_widget_scripts();
+}
+
+add_action( 'woocommerce_process_registration_errors', 'frcaptcha_wc_register_validate', 20, 3 );	
+
+function frcaptcha_wc_register_validate($validation_error) {
+
+    if ( empty( $_POST ) ) {
+        return;
+    }
+
+    $plugin = FriendlyCaptcha_Plugin::$instance;
+    if (!$plugin->is_configured() or !$plugin->get_wc_register_active()) {
+        return;
+    }
+
+    $errorPrefix = '<strong>' . __( 'Error', 'wp-captcha' ) . '</strong> : ';
+	$solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
+	
+	if ( empty( $solution ) ) {
+        $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message() . __(' (captcha missing)', 'frcaptcha');
+        $validation_error->add( 'frcaptcha-empty-error', $error_message );
+    }
+
+    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+
+    if (!$verification['success']) {
+        $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message();
+        $validation_error->add( 'frcaptcha-solution-error', $error_message );
+    }
+
+    return $validation_error;
+}

--- a/friendly-captcha/readme.txt
+++ b/friendly-captcha/readme.txt
@@ -63,6 +63,10 @@ A: Please see our website at: https://friendlycaptcha.com/
 * WordPress Register Form
 * WordPress Lost Password Form
 * Wordpress Comments
+* WooCommerce Login Form
+* WooCommerce Register Form
+* WooCommerce Checkout Form
+* WooCommerce Lost Password Form
 * WPForms
 * Contact Form 7
 * Gravity Forms


### PR DESCRIPTION
This adds WooCommerce support to this plugin. 

WooCommerce Login Form:
![image](https://user-images.githubusercontent.com/1368405/156862398-28032152-0ff5-489f-b429-007b6164c706.png)

WooCommerce Register Form:
![image](https://user-images.githubusercontent.com/1368405/156862415-97aec4d9-88e4-4f12-a634-13d735b04f72.png)

WooCommerce Lost Password Form:
![image](https://user-images.githubusercontent.com/1368405/156862512-3024b31d-e7d9-47c1-8dcd-e291d2c0d71b.png)

WooCommerce Checkout Form:
![image](https://user-images.githubusercontent.com/1368405/156862545-1c2ef1c5-32b9-4368-9c7f-a6a43a495928.png)

Settings Form: 
![image](https://user-images.githubusercontent.com/1368405/156862563-67206cc8-990f-44ce-b188-a301a3a48d48.png)

Closes #7 