### PR TITLE
Fix ultimate member captcha verification

### DIFF
--- a/friendly-captcha/modules/ultimate-member/ultimate-member_login.php
+++ b/friendly-captcha/modules/ultimate-member/ultimate-member_login.php
@@ -1,6 +1,6 @@
 <?php
 
-add_action( 'um_after_login_fields', 'frcaptcha_um_login_show_widget', 10, 0 );
+add_action( 'um_after_login_fields', 'frcaptcha_um_login_show_widget', 500 );
 
 function frcaptcha_um_login_show_widget() {
     $plugin = FriendlyCaptcha_Plugin::$instance;
@@ -16,32 +16,30 @@ function frcaptcha_um_login_show_widget() {
     frcaptcha_enqueue_widget_scripts();
 }
 
-add_action( 'um_submit_form_errors_hook', 'frcaptcha_um_login_validate', 20, 3 );	
+add_action( 'um_submit_form_errors_hook', 'frcaptcha_um_login_validate', 20 );	
 
-function frcaptcha_um_login_validate($args) {
-
-    if ( isset( $args['mode'] ) && ! $args['mode'] == 'login' && ! isset( $args['_social_login_form'] ) ) {
-		return;
-	}
-
-    $plugin = FriendlyCaptcha_Plugin::$instance;
-    if (!$plugin->is_configured() or !$plugin->get_um_login_active()) {
-        return;
-    }
-
-    $errorPrefix = '<strong>' . __( 'Error', 'frcaptcha' ) . '</strong> : ';
-	$solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
-	
-	if ( empty( $solution ) ) {
-        $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message() . __(' (captcha missing)', 'frcaptcha');
-        UM()->form()->add_error( 'frcaptcha', $error_message );
-		return;
-    }
-
-    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
-
-    if (!$verification['success']) {
-        $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message();
-        UM()->form()->add_error( 'frcaptcha', $error_message );
+function frcaptcha_um_login_validate($post) {
+    if ( isset( $post['mode'] ) && $post['mode'] == 'login') {
+        $plugin = FriendlyCaptcha_Plugin::$instance;
+        if (!$plugin->is_configured() or !$plugin->get_um_login_active()) {
+            return;
+        }
+    
+        $errorPrefix = '<strong>' . __( 'Error', 'frcaptcha' ) . '</strong> : ';
+        $solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
+        
+        if ( empty( $solution ) ) {
+            $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message() . __(' (captcha missing)', 'frcaptcha');
+            UM()->form()->add_error( 'frcaptcha', $error_message );
+            return;
+        }
+    
+        $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+    
+        if (!$verification['success']) {
+            $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message();
+            UM()->form()->add_error( 'frcaptcha', $error_message );
+            return;
+        }
     }
 }

--- a/friendly-captcha/modules/ultimate-member/ultimate-member_register.php
+++ b/friendly-captcha/modules/ultimate-member/ultimate-member_register.php
@@ -1,6 +1,6 @@
 <?php
 
-add_action( 'um_after_register_fields', 'frcaptcha_um_register_show_widget', 10, 0 );
+add_action( 'um_after_register_fields', 'frcaptcha_um_register_show_widget', 500 );
 
 function frcaptcha_um_register_show_widget() {
     $plugin = FriendlyCaptcha_Plugin::$instance;
@@ -16,32 +16,30 @@ function frcaptcha_um_register_show_widget() {
     frcaptcha_enqueue_widget_scripts();
 }
 
-add_action( 'um_submit_form_errors_hook', 'frcaptcha_um_register_validate', 20, 3 );	
+add_action( 'um_submit_form_errors_hook', 'frcaptcha_um_register_validate', 20 );	
 
-function frcaptcha_um_register_validate($args) {
-
-    if ( isset( $args['mode'] ) && ! $args['mode'] == 'register' && ! isset( $args['_social_login_form'] ) ) {
-		return;
-	}
-
-    $plugin = FriendlyCaptcha_Plugin::$instance;
-    if (!$plugin->is_configured() or !$plugin->get_um_register_active()) {
-        return;
-    }
-
-    $errorPrefix = '<strong>' . __( 'Error', 'frcaptcha' ) . '</strong> : ';
-	$solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
-	
-	if ( empty( $solution ) ) {
-        $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message() . __(' (captcha missing)', 'frcaptcha');
-        UM()->form()->add_error( 'frcaptcha', $error_message );
-		return;
-    }
-
-    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
-
-    if (!$verification['success']) {
-        $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message();
-        UM()->form()->add_error( 'frcaptcha', $error_message );
+function frcaptcha_um_register_validate($post) {
+    if ( isset( $post['mode'] ) && $post['mode'] == 'register') {
+        $plugin = FriendlyCaptcha_Plugin::$instance;
+        if (!$plugin->is_configured() or !$plugin->get_um_register_active()) {
+            return;
+        }
+    
+        $errorPrefix = '<strong>' . __( 'Error', 'frcaptcha' ) . '</strong>: ';
+        $solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
+        
+        if ( empty( $solution ) ) {
+            $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message() . __(' (captcha missing)', 'frcaptcha');
+            UM()->form()->add_error( 'frcaptcha', $error_message );
+            return;
+        }
+    
+        $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+    
+        if (!$verification['success']) {
+            $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message();
+            UM()->form()->add_error( 'frcaptcha', $error_message );
+            return;
+        }
     }
 }

--- a/friendly-captcha/modules/ultimate-member/ultimate-member_reset_password.php
+++ b/friendly-captcha/modules/ultimate-member/ultimate-member_reset_password.php
@@ -1,6 +1,6 @@
 <?php
 
-add_action( 'um_after_password_reset_fields', 'frcaptcha_um_reset_password_show_widget', 10, 0 );
+add_action( 'um_after_password_reset_fields', 'frcaptcha_um_reset_password_show_widget', 500 );
 
 function frcaptcha_um_reset_password_show_widget() {
     $plugin = FriendlyCaptcha_Plugin::$instance;
@@ -16,32 +16,30 @@ function frcaptcha_um_reset_password_show_widget() {
     frcaptcha_enqueue_widget_scripts();
 }
 
-add_action( 'um_reset_password_errors_hook', 'frcaptcha_um_reset_password_validate', 20, 3 );	
+add_action( 'um_reset_password_errors_hook', 'frcaptcha_um_reset_password_validate', 20 );	
 
-function frcaptcha_um_reset_password_validate($args) {
+function frcaptcha_um_reset_password_validate($post) {
+    if ( isset( $post['mode'] ) && $post['mode'] == 'password') {
+        $plugin = FriendlyCaptcha_Plugin::$instance;
+        if (!$plugin->is_configured() or !$plugin->get_um_reset_password_active()) {
+            return;
+        }
 
-    if ( isset( $args['mode'] ) && ! $args['mode'] == 'password' && ! isset( $args['_social_login_form'] ) ) {
-		return;
-	}
+        $errorPrefix = '<strong>' . __( 'Error', 'frcaptcha' ) . '</strong> : ';
+        $solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
+        
+        if ( empty( $solution ) ) {
+            $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message() . __(' (captcha missing)', 'frcaptcha');
+            UM()->form()->add_error( 'frcaptcha', $error_message );
+            return;
+        }
 
-    $plugin = FriendlyCaptcha_Plugin::$instance;
-    if (!$plugin->is_configured() or !$plugin->get_um_reset_password_active()) {
-        return;
-    }
+        $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
 
-    $errorPrefix = '<strong>' . __( 'Error', 'frcaptcha' ) . '</strong> : ';
-	$solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
-	
-	if ( empty( $solution ) ) {
-        $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message() . __(' (captcha missing)', 'frcaptcha');
-        UM()->form()->add_error( 'frcaptcha', $error_message );
-		return;
-    }
-
-    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
-
-    if (!$verification['success']) {
-        $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message();
-        UM()->form()->add_error( 'frcaptcha', $error_message );
+        if (!$verification['success']) {
+            $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message();
+            UM()->form()->add_error( 'frcaptcha', $error_message );
+            return;
+        }
     }
 }

--- a/friendly-captcha/modules/woocommerce/woocommerce_checkout.php
+++ b/friendly-captcha/modules/woocommerce/woocommerce_checkout.php
@@ -29,7 +29,7 @@ function frcaptcha_wc_checkout_validate() {
         return;
     }
 
-    $errorPrefix = '<strong>' . __( 'Error', 'frcaptcha' ) . '</strong> : ';
+    $errorPrefix = '<strong>' . __( 'Error', 'frcaptcha' ) . '</strong>: ';
 	$solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
 	
 	if ( empty( $solution ) ) {

--- a/friendly-captcha/modules/woocommerce/woocommerce_login.php
+++ b/friendly-captcha/modules/woocommerce/woocommerce_login.php
@@ -29,7 +29,7 @@ function frcaptcha_wc_login_validate($validation_error) {
         return;
     }
 
-    $errorPrefix = '<strong>' . __( 'Error', 'wp-captcha' ) . '</strong> : ';
+    $errorPrefix = '<strong>' . __( 'Error', 'wp-captcha' ) . '</strong>: ';
 	$solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
 	
 	if ( empty( $solution ) ) {

--- a/friendly-captcha/modules/woocommerce/woocommerce_register.php
+++ b/friendly-captcha/modules/woocommerce/woocommerce_register.php
@@ -29,7 +29,7 @@ function frcaptcha_wc_register_validate($validation_error) {
         return;
     }
 
-    $errorPrefix = '<strong>' . __( 'Error', 'frcaptcha' ) . '</strong> : ';
+    $errorPrefix = '<strong>' . __( 'Error', 'frcaptcha' ) . '</strong>: ';
 	$solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
 	
 	if ( empty( $solution ) ) {


### PR DESCRIPTION
Since ultimate members uses the same action for both the login and the registration form, this action was called twice on every login. This caused a duplication error by friendly captcha. 
This PR fixes this by wrapping the action with a condition, that checks which form is used. 