### PR TITLE
Fix ultimate member double captcha request when WP login captcha is active as well

### DIFF
--- a/friendly-captcha/modules/wordpress/wordpress_login.php
+++ b/friendly-captcha/modules/wordpress/wordpress_login.php
@@ -44,3 +44,13 @@ function frcaptcha_wp_login_validate($user, $username, $password) {
 
     return $user;
 }
+
+
+/* Remove the captcha hook, when Ultimate Member is used, so it does not get called twice */
+add_filter( 'um_submit_form_errors_hook_login', 'remove_filter_authenticate' );
+
+function remove_filter_authenticate( $credentials ) {
+    remove_filter( 'authenticate', 'frcaptcha_wp_login_validate', 20 );
+
+    return $credentials;
+}


### PR DESCRIPTION
I realized, that the UM integration still did not work when the native wordpress login form integration was active as well, so I debugged a little bit.

It seems, that UM integrated with the native wordpress login hook:
https://github.com/ultimatemember/ultimatemember/blob/df4d0c3543d7d22e067fa89f10a32eeec5e9604a/includes/core/um-actions-login.php#L66

which is also triggered here:
https://github.com/FriendlyCaptcha/friendly-captcha-wordpress/blob/8c02f58b6bce5dbf04fba6c8ab0a510d064cf084/friendly-captcha/modules/wordpress/wordpress_login.php#L19

So when UM starts a verification request, this hook will also start another verification request, which leads to captcha errors. 
~~I fixed this by checking, if the request was made by UM or not and in case it was made by UM I ignore it and do not start the second request. Maybe there is a more elegant solution to this, but this works fine.~~

**Update:** I found a more elegant solution by removing the filter wordpress login verification filter, when the login request is made by UM. I think this is a much better solution to the issue.


But please test this with wordpress native login and UM login. Thanks!