### PR TITLE
If Javascript has been deactivated, we wan't to flag it as spam (In Contact Form 7)

### DIFF
--- a/friendly-captcha/modules/contact-form-7/contact-form-7.php
+++ b/friendly-captcha/modules/contact-form-7/contact-form-7.php
@@ -69,7 +69,7 @@ function frcaptcha_wpcf7_friendly_captcha_verify_response($spam)
 			'agent' => 'friendly-captcha',
 			'reason' => __('FriendlyCaptcha solution value frc-captcha-solution was missing', 'frcaptcha'),
 		));
-		return $spam;
+		return true;
 	}
 
 	$verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());

--- a/friendly-captcha/modules/contact-form-7/contact-form-7.php
+++ b/friendly-captcha/modules/contact-form-7/contact-form-7.php
@@ -65,11 +65,11 @@ function frcaptcha_wpcf7_friendly_captcha_verify_response($spam)
 	$submission = WPCF7_Submission::get_instance();
 
 	if (empty($solution)) {
-		$spam = true;
 		$submission->add_spam_log(array(
 			'agent' => 'friendly-captcha',
 			'reason' => __('FriendlyCaptcha solution value frc-captcha-solution was missing', 'frcaptcha'),
 		));
+		return $spam;
 	}
 
 	$verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());


### PR DESCRIPTION
Hello,

i know that this is not the most inclusive thing to do but i just had another customer who was confused why FC wouldn't just flag emails as spam when you have javascript deactivated and to be fair i was confused about that as well. 

So the issue is, that the FC Server responses with a 401 Statuscode when you send an empty solution to it but in the CF7 Module everything that is not a 200 Statuscode will get a "success". 
```php
if ( 200 != $status ) {
	if ( WP_DEBUG ) {
              frcaptcha_log_remote_request( $endpoint, $request, $response );
              // error_log("The body was " . $body);
	}
          // Better safe than sorry, if the request is non-200 we can not verify the response
          // Either the user's credentials are wrong (e.g. wrong sitekey, api key) or the friendly
	// captcha servers are unresponsive.
	
	// TODO notify site admin somehow
	return array(
              "success" => true,
              "status" => $status,
              "errors" => array(),
              "response_body" => $response_body
          );
      }
```
It is also a bit confusing why there even was a verification of the solution when you already have checked that the solution is empty. 

So i pretty much just return the $spam as true.