### PR TITLE
Elementor Pro Forms Integration

### DIFF
--- a/friendly-captcha/includes/core.php
+++ b/friendly-captcha/includes/core.php
@@ -26,6 +26,7 @@
         public static $option_gravity_forms_integration_active_name = "frcaptcha_gravity_forms_integration_active";
         public static $option_coblocks_integration_active_name = "frcaptcha_coblocks_integration_active";
         public static $option_fluentform_integration_active_name = "frcaptcha_fluentform_integration_active";
+        public static $option_elementor_forms_integration_active_name = "frcaptcha_elementor_integration_active";
 
         public static $option_wp_register_integration_active_name = "frcaptcha_wp_register_integration_active";
         public static $option_wp_login_integration_active_name = "frcaptcha_wp_login_integration_active";
@@ -101,6 +102,10 @@
 
         public function get_fluentform_active() {
             return get_option(FriendlyCaptcha_Plugin::$option_fluentform_integration_active_name) == 1;
+        }
+
+        public function get_elementor_active() {
+            return get_option(FriendlyCaptcha_Plugin::$option_elementor_forms_integration_active_name) == 1;
         }
 
         public function get_wp_register_active() {
@@ -211,6 +216,10 @@
 
     if (FriendlyCaptcha_Plugin::$instance->get_fluentform_active()) {
         require plugin_dir_path( __FILE__ ) . '../modules/fluentform/fluentform.php';
+    }
+
+    if (FriendlyCaptcha_Plugin::$instance->get_elementor_active()) {
+        require plugin_dir_path( __FILE__ ) . '../modules/elementor/elementor.php';
     }
 
     if (FriendlyCaptcha_Plugin::$instance->get_wp_register_active()) {

--- a/friendly-captcha/includes/settings.php
+++ b/friendly-captcha/includes/settings.php
@@ -214,12 +214,12 @@ if (is_admin()) {
 
         add_settings_field(
             'frcaptcha_settings_elementor_integration_field',
-            'Elementor', 'frcaptcha_settings_field_callback',
+            'Elementor Pro Forms', 'frcaptcha_settings_field_callback',
             'friendly_captcha_admin',
             'frcaptcha_integrations_settings_section',
             array(
                 "option_name" => FriendlyCaptcha_Plugin::$option_elementor_forms_integration_active_name,
-                "description" => "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/elementor/\" target=\"_blank\">Elementor</a> forms.<br> The widget is available as a field type for Elementor Pro Forms. Add it as a field to the forms that you want to protect.",
+                "description" => "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/elementor/\" target=\"_blank\">Elementor Pro</a> forms.<br> The widget is available as a field type in Elementor Pro form editor. Add it as a field to the forms that you want to protect.",
                 "type" => "checkbox"
             )
         );

--- a/friendly-captcha/includes/settings.php
+++ b/friendly-captcha/includes/settings.php
@@ -37,6 +37,10 @@ if (is_admin()) {
         );
         register_setting(
             FriendlyCaptcha_Plugin::$option_group,
+            FriendlyCaptcha_Plugin::$option_elementor_forms_integration_active_name
+        );
+        register_setting(
+            FriendlyCaptcha_Plugin::$option_group,
             FriendlyCaptcha_Plugin::$option_wp_register_integration_active_name
         );
         register_setting(
@@ -204,6 +208,18 @@ if (is_admin()) {
             array(
                 "option_name" => FriendlyCaptcha_Plugin::$option_fluentform_integration_active_name,
                 "description" => "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/fluentform/\" target=\"_blank\">Fluentform</a> forms.<br>",
+                "type" => "checkbox"
+            )
+        );
+
+        add_settings_field(
+            'frcaptcha_settings_elementor_integration_field',
+            'Elementor', 'frcaptcha_settings_field_callback',
+            'friendly_captcha_admin',
+            'frcaptcha_integrations_settings_section',
+            array(
+                "option_name" => FriendlyCaptcha_Plugin::$option_elementor_forms_integration_active_name,
+                "description" => "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/elementor/\" target=\"_blank\">Elementor</a> forms.",
                 "type" => "checkbox"
             )
         );

--- a/friendly-captcha/includes/settings.php
+++ b/friendly-captcha/includes/settings.php
@@ -219,7 +219,7 @@ if (is_admin()) {
             'frcaptcha_integrations_settings_section',
             array(
                 "option_name" => FriendlyCaptcha_Plugin::$option_elementor_forms_integration_active_name,
-                "description" => "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/elementor/\" target=\"_blank\">Elementor</a> forms.",
+                "description" => "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/elementor/\" target=\"_blank\">Elementor</a> forms.<br> The widget is available as a field type for Elementor Pro Forms. Add it as a field to the forms that you want to protect.",
                 "type" => "checkbox"
             )
         );

--- a/friendly-captcha/modules/elementor/elementor.php
+++ b/friendly-captcha/modules/elementor/elementor.php
@@ -1,0 +1,16 @@
+<?php
+
+// https://developers.elementor.com/docs/form-fields/add-new-field/
+
+function add_form_field( $form_fields_registrar ) {
+    $plugin = FriendlyCaptcha_Plugin::$instance;
+    if (!$plugin->is_configured() or !$plugin->get_elementor_active()) {
+        return;
+    }
+
+	require_once( __DIR__ . '/field.php' );
+
+	$form_fields_registrar->register( new \Elementor_Form_Friendlycaptcha_Field() );
+
+}
+add_action( 'elementor_pro/forms/fields/register', 'add_form_field' );

--- a/friendly-captcha/modules/elementor/field.php
+++ b/friendly-captcha/modules/elementor/field.php
@@ -91,8 +91,7 @@ class Elementor_Form_Friendlycaptcha_Field extends \ElementorPro\Modules\Forms\F
 			return;
 		}
 
-        // I haven't figured out how to remove the label yet
-        $control_data = $this->remove_control_form_field_type( 'width', $control_data );
+        $control_data = $this->remove_control_form_field_type( 'required', $control_data ); // The captcha is always required
 
 		$widget->update_control( 'form_fields', $control_data );
 	}
@@ -113,4 +112,42 @@ class Elementor_Form_Friendlycaptcha_Field extends \ElementorPro\Modules\Forms\F
         }
         return $control_data;
     }
+
+    public function __construct() {
+		parent::__construct();
+		add_action( 'elementor/preview/init', [ $this, 'editor_preview_footer' ] );
+	}
+
+	public function editor_preview_footer() {
+		add_action( 'wp_footer', [ $this, 'content_template_script' ] );
+	}
+
+	public function content_template_script() {
+		?>
+		<script>
+		jQuery( document ).ready( () => {
+
+			elementor.hooks.addFilter(
+				'elementor_pro/forms/content_template/field/<?php echo $this->get_type(); ?>',
+				function ( inputField, item, i ) {
+					const fieldId = `form_field_${i}`;
+
+                    // We render a placeholder instead of the real widget here
+                    // The real widget messed with the Elementor editor
+					return `<div id="${fieldId}" style="
+                        position: relative;
+	                    min-width: 250px;
+	                    max-width: 312px;
+                        text-align: center;
+	                    border: 1px solid #f4f4f4;
+	                    padding-bottom: 20px;
+                        padding-top: 20px;
+	                    background-color: #fff;">Anti-Robot Verification</div>`;
+				}, 10, 3
+			);
+
+		});
+		</script>
+		<?php
+	}
 }

--- a/friendly-captcha/modules/elementor/field.php
+++ b/friendly-captcha/modules/elementor/field.php
@@ -43,8 +43,17 @@ class Elementor_Form_Friendlycaptcha_Field extends \ElementorPro\Modules\Forms\F
         
 		echo frcaptcha_generate_widget_tag_from_plugin($plugin);
         frcaptcha_enqueue_widget_scripts();
-
         echo "<style>.frc-captcha {max-width: 100%; width:100%}</style>";
+
+        // We render a hidden field so Elementor knows where to display errors
+        $form->add_render_attribute(
+			'input' . $item_index,
+			[
+				'type'        => 'text',
+				'style'       => 'display: none',
+			]
+		);
+		echo '<input ' . $form->get_render_attribute_string( 'input' . $item_index ) . '>';
 	}
 
 	/**

--- a/friendly-captcha/modules/elementor/field.php
+++ b/friendly-captcha/modules/elementor/field.php
@@ -1,0 +1,116 @@
+<?php
+
+if ( ! class_exists( '\ElementorPro\Modules\Forms\Fields\Field_Base' ) ) {
+	die();
+}
+
+// https://developers.elementor.com/docs/form-fields/advanced-example/
+
+class Elementor_Form_Friendlycaptcha_Field extends \ElementorPro\Modules\Forms\Fields\Field_Base {
+	/**
+	 * Get field type.
+	 *
+	 * @return string Field type.
+	 */
+	public function get_type() {
+		return 'frcaptcha';
+	}
+
+	/**
+	 * Get field name.
+	 *
+	 * @return string Field name.
+	 */
+	public function get_name() {
+		return esc_html__( 'FriendlyCaptcha', 'elementor-form-frcaptcha-field' );
+	}
+
+	/**
+	 * Render field output on the frontend.
+	 *
+	 * Written in PHP and used to generate the final HTML.
+	 *
+	 * @param mixed $item
+	 * @param mixed $item_index
+	 * @param mixed $form
+	 * @return void
+	 */
+	public function render( $item, $item_index, $form ) {
+        $plugin = FriendlyCaptcha_Plugin::$instance;
+        if (!$plugin->is_configured() or !$plugin->get_elementor_active()) {
+            return;
+        }
+        
+		echo frcaptcha_generate_widget_tag_from_plugin($plugin);
+        frcaptcha_enqueue_widget_scripts();
+	}
+
+	/**
+	 * Field validation.
+	 *
+	 * @param \ElementorPro\Modules\Forms\Classes\Field_Base   $field
+	 * @param \ElementorPro\Modules\Forms\Classes\Form_Record  $record
+	 * @param \ElementorPro\Modules\Forms\Classes\Ajax_Handler $ajax_handler
+	 * @return void
+	 */
+	public function validation( $field, $record, $ajax_handler ) {
+        $plugin = FriendlyCaptcha_Plugin::$instance;
+        if (!$plugin->is_configured() or !$plugin->get_elementor_active()) {
+            return;
+        }
+
+        $solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
+
+		if ( empty ( $solution ) ) {
+            $error_message = FriendlyCaptcha_Plugin::default_error_user_message() . __(" (captcha missing)", "frcaptcha");
+            $ajax_handler->add_error(
+				$field['id'],
+				esc_html__( $error_message, 'elementor-form-frcaptcha-field' )
+			);
+			return;
+		}
+
+        $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+
+        if (!$verification["success"]) {
+            $error_message = FriendlyCaptcha_Plugin::default_error_user_message();
+            $ajax_handler->add_error(
+				$field['id'],
+				esc_html__( $error_message, 'elementor-form-frcaptcha-field' )
+			);
+            return;
+        }
+	}
+
+    public function update_controls( $widget ) {
+		$elementor = \ElementorPro\Plugin::elementor();
+
+		$control_data = $elementor->controls_manager->get_control_from_stack( $widget->get_unique_name(), 'form_fields' );
+
+		if ( is_wp_error( $control_data ) ) {
+			return;
+		}
+
+        // I haven't figured out how to remove the label yet
+        $control_data = $this->remove_control_form_field_type( 'width', $control_data );
+
+		$widget->update_control( 'form_fields', $control_data );
+	}
+    
+    private function remove_control_form_field_type( $control_name, $control_data ) {
+        foreach ( $control_data['fields'] as $index => $field ) {
+            if ( $control_name !== $field['name'] ) {
+                continue;
+            }
+            foreach ( $field['conditions']['terms'] as $condition_index => $terms ) {
+                if ( ! isset( $terms['name'] ) || 'field_type' !== $terms['name'] || ! isset( $terms['operator'] ) || '!in' !== $terms['operator'] ) {
+                    continue;
+                }
+                $control_data['fields'][ $index ]['conditions']['terms'][ $condition_index ]['value'][] = $this->get_type();
+                break;
+            }
+            break;
+        }
+        return $control_data;
+    }
+}

--- a/friendly-captcha/modules/elementor/field.php
+++ b/friendly-captcha/modules/elementor/field.php
@@ -43,6 +43,8 @@ class Elementor_Form_Friendlycaptcha_Field extends \ElementorPro\Modules\Forms\F
         
 		echo frcaptcha_generate_widget_tag_from_plugin($plugin);
         frcaptcha_enqueue_widget_scripts();
+
+        echo "<style>.frc-captcha {max-width: 100%; width:100%}</style>";
 	}
 
 	/**
@@ -136,8 +138,7 @@ class Elementor_Form_Friendlycaptcha_Field extends \ElementorPro\Modules\Forms\F
                     // The real widget messed with the Elementor editor
 					return `<div id="${fieldId}" style="
                         position: relative;
-	                    min-width: 250px;
-	                    max-width: 312px;
+	                    width: 100%;
                         text-align: center;
 	                    border: 1px solid #f4f4f4;
 	                    padding-bottom: 20px;

--- a/friendly-captcha/modules/elementor/index.php
+++ b/friendly-captcha/modules/elementor/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.


### PR DESCRIPTION
- [x] Add form field for friendly captcha
- [x] Validate captcha solution on submit
- [x] Display errors correctly (only a generic error is displayed right now)
- [x] Check if the most common use-cases are covered
- [x] Widget preview in editor (doesn't render atm for some reason)

We previously had issues implementing an integration for Elementor because their documentation was insufficient. Specifically the documentation for adding new form fields was missing, this was recently resolved and can be found here: https://developers.elementor.com/docs/form-fields/

closes #28
closes #14