### PR TITLE
Add setting to disable style injection

### DIFF
--- a/friendly-captcha/includes/core.php
+++ b/friendly-captcha/includes/core.php
@@ -19,6 +19,7 @@
         public static $option_group = "frcaptcha_options";
         public static $option_sitekey_name = "frcaptcha_sitekey";
         public static $option_api_key_name = "frcaptcha_api_key";
+        public static $option_skip_style_injection = "frcaptcha_skip_style_injection";
 
         // Integrations
         public static $option_contact_form_7_integration_active_name = "frcaptcha_contact_form_7_integration_active";
@@ -82,6 +83,10 @@
 
         public function get_api_key() {
             return trim(get_option(FriendlyCaptcha_Plugin::$option_api_key_name));
+        }
+
+        public function get_skip_style_injection() {
+            return get_option(FriendlyCaptcha_Plugin::$option_skip_style_injection) == 1;
         }
 
         public function get_contact_form_7_active() {

--- a/friendly-captcha/includes/settings.php
+++ b/friendly-captcha/includes/settings.php
@@ -14,6 +14,10 @@ if (is_admin()) {
             FriendlyCaptcha_Plugin::$option_group,
             FriendlyCaptcha_Plugin::$option_api_key_name
         );
+        register_setting(
+            FriendlyCaptcha_Plugin::$option_group,
+            FriendlyCaptcha_Plugin::$option_skip_style_injection
+        );
 
         register_setting(
             FriendlyCaptcha_Plugin::$option_group,
@@ -139,6 +143,18 @@ if (is_admin()) {
                 "option_name" => FriendlyCaptcha_Plugin::$option_api_key_name,
                 "description" => "Create a new API key in the <a href=\"https://app.friendlycaptcha.com/dashboard/\" target=\"_blank\">account panel</a> and paste the value here. Keep this one secret!",
                 "type" => "password"
+            )
+        );
+
+        add_settings_field(
+            'frcaptcha_settings_skip_style_injection_field',
+            'Disable Style Injection', 'frcaptcha_settings_field_callback',
+            'friendly_captcha_admin',
+            'frcaptcha_general_settings_section',
+            array(
+                "option_name" => FriendlyCaptcha_Plugin::$option_skip_style_injection,
+                "description" => "Don't load the CSS-Styles for the widget. Use this if you want to style the widget yourself.",
+                "type" => "checkbox"
             )
         );
 

--- a/friendly-captcha/includes/settings.php
+++ b/friendly-captcha/includes/settings.php
@@ -146,18 +146,6 @@ if (is_admin()) {
             )
         );
 
-        add_settings_field(
-            'frcaptcha_settings_skip_style_injection_field',
-            'Disable Style Injection', 'frcaptcha_settings_field_callback',
-            'friendly_captcha_admin',
-            'frcaptcha_general_settings_section',
-            array(
-                "option_name" => FriendlyCaptcha_Plugin::$option_skip_style_injection,
-                "description" => "Don't load the CSS-Styles for the widget. Use this if you want to style the widget yourself.",
-                "type" => "checkbox"
-            )
-        );
-
         /* Integrations section */
 
         // Section
@@ -414,6 +402,18 @@ if (is_admin()) {
             array(
                 "option_name" => FriendlyCaptcha_Plugin::$option_widget_dark_theme_active_name,
                 "description" => "Enable a dark theme for Friendly Captcha widgets.",
+                "type" => "checkbox"
+            )
+        );
+
+        add_settings_field(
+            'frcaptcha_settings_skip_style_injection_field',
+            'Disable Style Injection', 'frcaptcha_settings_field_callback',
+            'friendly_captcha_admin',
+            'frcaptcha_widget_settings_section',
+            array(
+                "option_name" => FriendlyCaptcha_Plugin::$option_skip_style_injection,
+                "description" => "Don't load the CSS-Styles for the widget. Use this if you want to style the widget yourself.",
                 "type" => "checkbox"
             )
         );

--- a/friendly-captcha/public/widgets.php
+++ b/friendly-captcha/public/widgets.php
@@ -76,7 +76,11 @@ function frcaptcha_generate_widget_tag_from_plugin($plugin) {
 
     $theme = $plugin->get_widget_dark_theme_active() ? "dark" : "";
 
-    return frcaptcha_generate_widget_tag($sitekey, $lang, $extra_attributes, $theme);
+    return sprintf(
+        '%s%s',
+        frcaptcha_generate_skip_style_injection_tag($plugin),
+        frcaptcha_generate_widget_tag($sitekey, $lang, $extra_attributes, $theme)
+    );
 }
 
 function frcaptcha_generate_widget_tag($sitekey, $language, $extra_attributes = "", $theme = "") {
@@ -87,6 +91,22 @@ function frcaptcha_generate_widget_tag($sitekey, $language, $extra_attributes = 
     esc_html($sitekey),
     esc_html($language),
     $extra_attributes);
+}
+
+$frcaptcha_skip_style_injection_tag_injected = false;
+
+function frcaptcha_generate_skip_style_injection_tag($plugin) {
+    if (!$plugin->get_skip_style_injection()) {
+        return '';
+    }
+
+    if ($frcaptcha_skip_style_injection_tag_injected) {
+        // we only want to inject the element once
+        return '';
+    }
+
+    $frcaptcha_skip_style_injection_tag_injected = true;
+    return '<div id="frc-style"></div>';
 }
 
 function frcaptcha_generate_extra_widget_attributes($plugin) {


### PR DESCRIPTION
This PR adds a new plugin setting which allows users to disable the injection of our CSS styles. This was requested by a customer.
It works by injecting an element with the id `frc-style` which is checked for by widget: https://github.com/FriendlyCaptcha/friendly-challenge/blob/master/src/dom.ts#L110

<img width="853" alt="grafik" src="https://user-images.githubusercontent.com/33966852/203321439-d452b527-316d-4ead-bc94-6d623bb5f2e3.png">


closes #66