### PR TITLE
add html forms integration

### DIFF
--- a/friendly-captcha/includes/core.php
+++ b/friendly-captcha/includes/core.php
@@ -27,6 +27,7 @@
         public static $option_coblocks_integration_active_name = "frcaptcha_coblocks_integration_active";
         public static $option_fluentform_integration_active_name = "frcaptcha_fluentform_integration_active";
         public static $option_elementor_forms_integration_active_name = "frcaptcha_elementor_integration_active";
+        public static $option_html_forms_integration_active_name = "frcaptcha_html_forms_integration_active";
 
         public static $option_wp_register_integration_active_name = "frcaptcha_wp_register_integration_active";
         public static $option_wp_login_integration_active_name = "frcaptcha_wp_login_integration_active";
@@ -106,6 +107,10 @@
 
         public function get_elementor_active() {
             return get_option(FriendlyCaptcha_Plugin::$option_elementor_forms_integration_active_name) == 1;
+        }
+
+        public function get_html_forms_active() {
+            return get_option(FriendlyCaptcha_Plugin::$option_html_forms_integration_active_name) == 1;
         }
 
         public function get_wp_register_active() {
@@ -227,6 +232,10 @@
 
     if (FriendlyCaptcha_Plugin::$instance->get_elementor_active()) {
         require plugin_dir_path( __FILE__ ) . '../modules/elementor/elementor.php';
+    }
+
+    if (FriendlyCaptcha_Plugin::$instance->get_html_forms_active()) {
+        require plugin_dir_path( __FILE__ ) . '../modules/html-forms/html-forms.php';
     }
 
     if (FriendlyCaptcha_Plugin::$instance->get_wp_register_active()) {

--- a/friendly-captcha/includes/settings.php
+++ b/friendly-captcha/includes/settings.php
@@ -41,6 +41,10 @@ if (is_admin()) {
         );
         register_setting(
             FriendlyCaptcha_Plugin::$option_group,
+            FriendlyCaptcha_Plugin::$option_html_forms_integration_active_name
+        );
+        register_setting(
+            FriendlyCaptcha_Plugin::$option_group,
             FriendlyCaptcha_Plugin::$option_wp_register_integration_active_name
         );
         register_setting(
@@ -220,6 +224,18 @@ if (is_admin()) {
             array(
                 "option_name" => FriendlyCaptcha_Plugin::$option_elementor_forms_integration_active_name,
                 "description" => "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/elementor/\" target=\"_blank\">Elementor Pro</a> forms.<br> The widget is available as a field type in Elementor Pro form editor. Add it as a field to the forms that you want to protect.",
+                "type" => "checkbox"
+            )
+        );
+
+        add_settings_field(
+            'frcaptcha_settings_html_forms_integration_field',
+            'HTML Forms', 'frcaptcha_settings_field_callback',
+            'friendly_captcha_admin',
+            'frcaptcha_integrations_settings_section',
+            array(
+                "option_name" => FriendlyCaptcha_Plugin::$option_html_forms_integration_active_name,
+                "description" => "Enable Friendly Captcha for <a href=\"https://de.wordpress.org/plugins/html-forms/\" target=\"_blank\">HTML Forms</a>.",
                 "type" => "checkbox"
             )
         );

--- a/friendly-captcha/modules/html-forms/html-forms.php
+++ b/friendly-captcha/modules/html-forms/html-forms.php
@@ -9,7 +9,7 @@ add_filter( 'hf_form_html', function( $html ) {
     frcaptcha_enqueue_widget_scripts();
 
     $widget = frcaptcha_generate_widget_tag_from_plugin($plugin);
-    $html = str_replace( '</form>', $widget, $html );
+    $html = str_replace( '</form>', $widget . '</form>', $html );
 	return $html;
 });
 

--- a/friendly-captcha/modules/html-forms/html-forms.php
+++ b/friendly-captcha/modules/html-forms/html-forms.php
@@ -1,0 +1,43 @@
+<?php
+
+add_filter( 'hf_form_html', function( $html ) {
+    $plugin = FriendlyCaptcha_Plugin::$instance;
+    if (!$plugin->is_configured() or !$plugin->get_html_forms_active()) {
+        return;
+    }
+
+    frcaptcha_enqueue_widget_scripts();
+
+    $widget = frcaptcha_generate_widget_tag_from_plugin($plugin);
+    $html = str_replace( '</form>', $widget, $html );
+	return $html;
+});
+
+add_filter( 'hf_validate_form', function( $error_code, $form, $data ) {
+    $plugin = FriendlyCaptcha_Plugin::$instance;
+    if (!$plugin->is_configured() or !$plugin->get_html_forms_active()) {
+        return $error_code;
+    }
+
+    $solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
+
+    if ( empty( $solution ) ) {
+        return 'frcaptcha_empty';
+    }
+
+    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+
+    if ( !$verification["success"] ) {
+        return 'frcaptcha_invalid';
+    }
+
+	return $error_code;
+}, 10, 3 );
+
+add_filter( 'hf_form_message_frcaptcha_empty', function( $message ) {
+    return FriendlyCaptcha_Plugin::default_error_user_message() . __(" (captcha missing)", "frcaptcha");
+});
+
+add_filter( 'hf_form_message_frcaptcha_invalid', function( $message ) {
+    return FriendlyCaptcha_Plugin::default_error_user_message();
+});

--- a/friendly-captcha/modules/html-forms/index.php
+++ b/friendly-captcha/modules/html-forms/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/friendly-captcha/readme.txt
+++ b/friendly-captcha/readme.txt
@@ -89,6 +89,11 @@ However, you may wish to email the authors of plugins you'd like to support Frie
 
 == Changelog ==
 
+= 1.7.3 (unreleased) =
+* Add support for HTML forms
+* Fix widget not loading with Gravity Form integration
+* Add setting to disable the loading of CSS styles
+
 = 1.7.2 =
 * Update to widget library version 0.9.8, which fixes rare cases in which the widget wouldn't work for users with specific browsers plugins installed.
 


### PR DESCRIPTION
This PR adds integration for [HTML Forms](https://de.wordpress.org/plugins/html-forms/).

closes #68