### PR TITLE
Fix Gravity Forms issue

### DIFF
--- a/friendly-captcha/modules/gravityforms/field.php
+++ b/friendly-captcha/modules/gravityforms/field.php
@@ -83,9 +83,7 @@ class GFForms_Friendlycaptcha_Field extends GF_Field {
 
 		$is_form_editor  = $this->is_form_editor();
 
-		add_action( 'wp_footer', function() {
-			frcaptcha_enqueue_widget_scripts();
-		});
+		frcaptcha_enqueue_widget_scripts();
 			
 		add_action( 'gform_preview_footer', array( $this, 'ensure_frcaptcha_init' ) );
 


### PR DESCRIPTION
As described in #70 some wordpress themes don't call the `wp_footer` hook and our gravity forms integration therefore doesn't work with them.
To fix this I just enqueue the scripts directly when the form field is generated. It shouldn't matter when the scripts are enqueued because wordpress takes care of loading them at the right time. Enqueuing them multiple times is also not an issue.
According to the Wordpress docs for wp_enqueue_script:
> Links a script file to the generated page at the right time according to the script dependencies, if the script has not been already included and if all the dependencies have been registered.

fixes #70