### PR TITLE
Pass login via woocommerce to woocommerce component instead of wordpress login

### DIFF
--- a/friendly-captcha/modules/wordpress/wordpress_login.php
+++ b/friendly-captcha/modules/wordpress/wordpress_login.php
@@ -24,6 +24,10 @@ function frcaptcha_wp_login_validate($user, $username, $password) {
         return;
     }
 
+    if ( !empty( $_POST['woocommerce-login-nonce'] ) ) {
+        return $user;
+    }
+
     $plugin = FriendlyCaptcha_Plugin::$instance;
     if (!$plugin->is_configured() or !$plugin->get_wp_login_active()) {
         return;


### PR DESCRIPTION
I'm not sure if this is something that changed in the last wordpress / woocommerce updates, but when activating the woocommerce login captcha, the wordpress login captcha action is fired as well. This leads to friendly captcha beeing fired twice and therefore fails. 

The added code snipped should fix that by just passing the user object, when the login call is a woocommerce login call within the wordpress login action. 