### PR TITLE
Fix gravity forms integration for multi-page forms with ajax

### DIFF
--- a/friendly-captcha/modules/gravityforms/field.php
+++ b/friendly-captcha/modules/gravityforms/field.php
@@ -84,6 +84,14 @@ class GFForms_Friendlycaptcha_Field extends GF_Field {
 		$is_form_editor  = $this->is_form_editor();
 
 		frcaptcha_enqueue_widget_scripts();
+
+		wp_enqueue_script(
+			'frcaptcha_gravity_forms-friendly-captcha',
+			plugin_dir_url(__FILE__) . 'script.js',
+			array('friendly-captcha-widget-module', 'friendly-captcha-widget-fallback'),
+			FriendlyCaptcha_Plugin::$version,
+			true
+		);
 			
 		add_action( 'gform_preview_footer', array( $this, 'ensure_frcaptcha_init' ) );
 

--- a/friendly-captcha/modules/gravityforms/script.js
+++ b/friendly-captcha/modules/gravityforms/script.js
@@ -1,0 +1,24 @@
+(function () {
+  function findCaptchaElements() {
+    return document.querySelectorAll(".frc-captcha");
+  }
+
+  function setupCaptchaElements() {
+    let autoWidget = window.friendlyChallenge.autoWidget;
+
+    const elements = findCaptchaElements();
+    for (let index = 0; index < elements.length; index++) {
+      const hElement = elements[index];
+      if (hElement && !hElement.dataset["attached"]) {
+        autoWidget = new window.friendlyChallenge.WidgetInstance(hElement);
+        // We set the "data-attached" attribute so we don't attach to the same element twice.
+        hElement.dataset["attached"] = "1";
+      }
+    }
+    window.friendlyChallenge.autoWidget = autoWidget;
+  }
+
+  jQuery(document).ready(function () {
+    jQuery(document).on("gform_page_loaded", setupCaptchaElements);
+  });
+})();


### PR DESCRIPTION
I'm basically re-running the setup() function from https://github.com/FriendlyCaptcha/friendly-challenge/blob/master/src/main.ts when the form page is changed. This way we can find widgets that are added on later pages.

closes #74