### PR TITLE
Fix error codes being a string

### DIFF
--- a/friendly-captcha/includes/verification.php
+++ b/friendly-captcha/includes/verification.php
@@ -47,7 +47,7 @@ function frcaptcha_verify_captcha_solution($solution, $sitekey, $api_key) {
             : false;
 
         $errorCodes = isset( $response_body['errors'] )
-			? reset($response_body['errors'])
+			? $response_body['errors']
 			: array();
 
 

--- a/friendly-captcha/modules/gravityforms/field.php
+++ b/friendly-captcha/modules/gravityforms/field.php
@@ -153,7 +153,7 @@ class GFForms_Friendlycaptcha_Field extends GF_Field {
 		if (!$verification["success"]) {
 			$this->failed_validation  = true;
 			$this->validation_message = FriendlyCaptcha_Plugin::default_error_user_message();
-			GFCommon::log_debug( __METHOD__ . '(): Validating the Friendly Captcha response has failed due to the following: ' . $verification["error_codes"] );
+			GFCommon::log_debug( __METHOD__ . '(): Validating the Friendly Captcha response has failed due to the following: ' . reset($verification["error_codes"]) );
 			return;
 		}
 	}

--- a/friendly-captcha/readme.txt
+++ b/friendly-captcha/readme.txt
@@ -89,6 +89,9 @@ However, you may wish to email the authors of plugins you'd like to support Frie
 
 == Changelog ==
 
+= 1.8.1 (unreleased) =
+* Fix internal error becauses of wrong error_codes type
+
 = 1.8.0 =
 * Add support for HTML forms
 * Fix widget not loading with Gravity Form integration


### PR DESCRIPTION
Before this PR `error_codes` in the return value of `frcaptcha_verify_captcha_solution` was a string when there was an error and an empty array if there was non. Some functions were calling `next()` on that value which caused an PHP error.