### PR TITLE
Prepare for new wordpress version 6.2

### DIFF
--- a/friendly-captcha/readme.txt
+++ b/friendly-captcha/readme.txt
@@ -2,7 +2,7 @@
 Contributors: friendlycaptcha
 Tags: captcha, antispam, spam, contact form, recaptcha, friendly-captcha, block spam, anti-spam, comments, elementor
 Requires at least: 5.0
-Tested up to: 6.1
+Tested up to: 6.2
 Requires PHP: 7.3
 Stable tag: 1.9.0
 License: GPL v2 or later


### PR DESCRIPTION
I have tested the plugin with the newest beta release of Wordpress 6.2.

@dev-love Do I need to update the version somewhere else as well? Where does it pull the 6.1.1 on the plugin site from? I couldn't find anything in the code 🤔 

<img width="317" alt="grafik" src="https://user-images.githubusercontent.com/33966852/227036104-ab90f980-aab8-4ac4-b2aa-86dafc155a8e.png">
