### PR TITLE
Fix integration for wordpress login, register, and forgot password

### DIFF
--- a/friendly-captcha/modules/wordpress/wordpress_login.php
+++ b/friendly-captcha/modules/wordpress/wordpress_login.php
@@ -26,7 +26,7 @@ function frcaptcha_wp_login_validate($user, $username, $password) {
 
     $plugin = FriendlyCaptcha_Plugin::$instance;
     if (!$plugin->is_configured() or !$plugin->get_wp_login_active()) {
-        return;
+        return $user;
     }
 
     $errorPrefix = '<strong>' . __( 'Error', 'wp-captcha' ) . '</strong> : ';

--- a/friendly-captcha/modules/wordpress/wordpress_register.php
+++ b/friendly-captcha/modules/wordpress/wordpress_register.php
@@ -26,7 +26,7 @@ function frcaptcha_wp_register_validate($user_login, $user_email, $errors) {
 
     $plugin = FriendlyCaptcha_Plugin::$instance;
     if (!$plugin->is_configured() or !$plugin->get_wp_register_active()) {
-        return;
+        return $errors;
     }
 
     $errorPrefix = '<strong>' . __( 'Error', 'wp-captcha' ) . '</strong> : ';

--- a/friendly-captcha/modules/wordpress/wordpress_reset_password.php
+++ b/friendly-captcha/modules/wordpress/wordpress_reset_password.php
@@ -26,7 +26,7 @@ function frcaptcha_wp_reset_password_validate($val) {
 
     $plugin = FriendlyCaptcha_Plugin::$instance;
     if (!$plugin->is_configured() or !$plugin->get_wp_reset_password_active()) {
-        return;
+        return $val;
     }
 
     $errorPrefix = '<strong>' . __( 'Error', 'wp-captcha' ) . '</strong> : ';


### PR DESCRIPTION
According to the documentation of the `authenticate` hook we should return the `$user` variable if we want the login to succeed. Before this PR we returned nothing when the plugin is not configured correctly which will cause the authentication to fail. This is not what we want