### PR TITLE
change order of checks in login integrations and add meaningful error

### DIFF
--- a/friendly-captcha/modules/wordpress/wordpress_comments.php
+++ b/friendly-captcha/modules/wordpress/wordpress_comments.php
@@ -39,13 +39,14 @@ function frcaptcha_wp_comments_validate($comment) {
         return $comment;
     }
 
-    if ( empty( $_POST ) ) {
-        return;
-    }
-
     $plugin = FriendlyCaptcha_Plugin::$instance;
     if (!$plugin->is_configured() or (!$plugin->get_wp_comments_active() && !$plugin->get_wp_comments_logged_in_active())) {
         return $comment;
+    }
+
+    $errorPrefix = '<strong>' . __( 'Error', 'wp-captcha' ) . '</strong> : ';
+    if ( empty( $_POST ) ) {
+        return new WP_Error("frcaptcha-empty-error", $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message() . __(" (empty body)", "frcaptcha") );
     }
 
     // Guest user
@@ -57,7 +58,6 @@ function frcaptcha_wp_comments_validate($comment) {
         return $comment;
     }
 
-    $errorPrefix = '<strong>' . __( 'Error', 'wp-captcha' ) . '</strong> : ';
 	$solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
 	
 	if (empty( $solution )) {

--- a/friendly-captcha/modules/wordpress/wordpress_login.php
+++ b/friendly-captcha/modules/wordpress/wordpress_login.php
@@ -19,17 +19,16 @@ function frcaptcha_wp_login_show_widget() {
 add_filter( 'authenticate', 'frcaptcha_wp_login_validate', 20, 3 );	
 
 function frcaptcha_wp_login_validate($user, $username, $password) {
-
-    if ( empty( $_POST ) ) {
-        return;
-    }
-
     $plugin = FriendlyCaptcha_Plugin::$instance;
     if (!$plugin->is_configured() or !$plugin->get_wp_login_active()) {
         return $user;
     }
 
     $errorPrefix = '<strong>' . __( 'Error', 'wp-captcha' ) . '</strong> : ';
+    if ( empty( $_POST ) ) {
+        return new WP_Error("frcaptcha-empty-error", $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message() . __(" (empty body)", "frcaptcha") );
+    }
+
 	$solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
 	
 	if ( empty( $solution ) ) {

--- a/friendly-captcha/modules/wordpress/wordpress_register.php
+++ b/friendly-captcha/modules/wordpress/wordpress_register.php
@@ -19,17 +19,16 @@ function frcaptcha_wp_register_show_widget() {
 add_action( 'register_post', 'frcaptcha_wp_register_validate', 10, 3 );	
 
 function frcaptcha_wp_register_validate($user_login, $user_email, $errors) {
-
-    if ( empty( $_POST ) ) {
-        return;
-    }
-
     $plugin = FriendlyCaptcha_Plugin::$instance;
     if (!$plugin->is_configured() or !$plugin->get_wp_register_active()) {
         return $errors;
     }
 
     $errorPrefix = '<strong>' . __( 'Error', 'wp-captcha' ) . '</strong> : ';
+    if ( empty( $_POST ) ) {
+        return new WP_Error("frcaptcha-empty-error", $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message() . __(" (empty body)", "frcaptcha") );
+    }
+
 	$solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
 	
 	if ( empty( $solution ) ) {

--- a/friendly-captcha/modules/wordpress/wordpress_reset_password.php
+++ b/friendly-captcha/modules/wordpress/wordpress_reset_password.php
@@ -19,17 +19,16 @@ function frcaptcha_wp_reset_password_show_widget() {
 add_filter( 'lostpassword_post', 'frcaptcha_wp_reset_password_validate', 10, 1 );	
 
 function frcaptcha_wp_reset_password_validate($val) {
-
-    if ( empty( $_POST ) ) {
-        return;
-    }
-
     $plugin = FriendlyCaptcha_Plugin::$instance;
     if (!$plugin->is_configured() or !$plugin->get_wp_reset_password_active()) {
         return $val;
     }
 
     $errorPrefix = '<strong>' . __( 'Error', 'wp-captcha' ) . '</strong> : ';
+    if ( empty( $_POST ) ) {
+        return new WP_Error("frcaptcha-empty-error", $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message() . __(" (empty body)", "frcaptcha") );
+    }
+
 	$solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
 	
 	if ( empty( $solution ) ) {


### PR DESCRIPTION
To maybe fix or at least help troubleshoot the #97 I have changed the order of checks and added a meaningful error instead of returning null. Performing the check for the plugin configuration first makes more sense, as we want to let users through if the plugin isn't configured.