### PR TITLE
Fix login error being displayed on page load

### DIFF
--- a/friendly-captcha/modules/wordpress/wordpress_login.php
+++ b/friendly-captcha/modules/wordpress/wordpress_login.php
@@ -19,6 +19,10 @@ function frcaptcha_wp_login_show_widget() {
 add_filter( 'authenticate', 'frcaptcha_wp_login_validate', 20, 3 );	
 
 function frcaptcha_wp_login_validate($user, $username, $password) {
+    if ( $user instanceof WP_Error ) {
+        return $user;
+    }
+
     $plugin = FriendlyCaptcha_Plugin::$instance;
     if (!$plugin->is_configured() or !$plugin->get_wp_login_active()) {
         return $user;


### PR DESCRIPTION
Because the `authenticate` hook is being called for the first time when the page is loaded it would always display an error because the `POST` body would be empty. Now we check if there is already an error (which seems to be product by WP for GET requests) and then return that.

fixes #97 

https://wordpress.stackexchange.com/a/395662