### PR TITLE
Add support for f12 cf7 double opt in

### DIFF
--- a/friendly-captcha/includes/core.php
+++ b/friendly-captcha/includes/core.php
@@ -23,6 +23,7 @@
 
         // Integrations
         public static $option_contact_form_7_integration_active_name = "frcaptcha_contact_form_7_integration_active";
+        public static $option_f12_cf7_doubleoptin_integration_active_name = "frcaptcha_f12_cf7_doubleoptin_integration_active";
         public static $option_wpforms_integration_active_name = "frcaptcha_wpforms_integration_active";
         public static $option_gravity_forms_integration_active_name = "frcaptcha_gravity_forms_integration_active";
         public static $option_coblocks_integration_active_name = "frcaptcha_coblocks_integration_active";
@@ -101,6 +102,10 @@
 
         public function get_contact_form_7_active() {
             return get_option(FriendlyCaptcha_Plugin::$option_contact_form_7_integration_active_name) == 1;
+        }
+
+        public function get_f12_cf7_doubleoptin_active() {
+            return get_option(FriendlyCaptcha_Plugin::$option_f12_cf7_doubleoptin_integration_active_name) == 1;
         }
 
         public function get_wpforms_active() {

--- a/friendly-captcha/includes/settings.php
+++ b/friendly-captcha/includes/settings.php
@@ -25,6 +25,10 @@ if (is_admin()) {
         );
         register_setting(
             FriendlyCaptcha_Plugin::$option_group,
+            FriendlyCaptcha_Plugin::$option_f12_cf7_doubleoptin_integration_active_name
+        );
+        register_setting(
+            FriendlyCaptcha_Plugin::$option_group,
             FriendlyCaptcha_Plugin::$option_wpforms_integration_active_name
         );
         register_setting(
@@ -212,6 +216,18 @@ if (is_admin()) {
             array(
                 "option_name" => FriendlyCaptcha_Plugin::$option_contact_form_7_integration_active_name,
                 "description" => "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/contact-form-7/\" target=\"_blank\">Contact Form 7</a> forms.",
+                "type" => "checkbox"
+            )
+        );
+
+        add_settings_field(
+            'frcaptcha_settings_f12_cf7_doubleoptin_integration_field',
+            'CF7 Double-Opt-In', 'frcaptcha_settings_field_callback',
+            'friendly_captcha_admin',
+            'frcaptcha_integrations_settings_section',
+            array(
+                "option_name" => FriendlyCaptcha_Plugin::$option_f12_cf7_doubleoptin_integration_active_name,
+                "description" => "Enable support for the Forge12 Double Opt-In plugin for Contact Form 7. You need to enable Contact Form 7 as well.",
                 "type" => "checkbox"
             )
         );

--- a/friendly-captcha/modules/contact-form-7/contact-form-7.php
+++ b/friendly-captcha/modules/contact-form-7/contact-form-7.php
@@ -61,6 +61,14 @@ function frcaptcha_wpcf7_friendly_captcha_verify_response($spam)
 		return $spam;
 	}
 
+	if ($plugin->get_f12_cf7_doubleoptin_active()) {
+		// Forge12 Double Opt-In triggers a form submit when clicking the link in the email.
+		// That form submit will be a GET request and does not have the frc-captcha-solution field, so we need to let it pass.
+		if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['optin'])) {
+			return $spam;
+		}
+	}
+
 	$solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
 	$submission = WPCF7_Submission::get_instance();
 


### PR DESCRIPTION
A customer has reported that our plugin doesn't work together with the Forge12 Contact Form 7 Double Opt-In plugin. I think this is because the plugin triggers a second form submit after clicking the opt-in link in the email which is rejected by our plugin because of the missing captcha solution.
I have added a new setting to let this second submit bypass the captcha check. This happens by checking if it's a GET request (not the case for normal form submits) and if the `optin` query parameter is set. As this is not a perfect check and may open some unforeseen security holes users have to explicitly enable this.