### PR TITLE
Initialize widgets that are dynamically added to the page

### DIFF
--- a/friendly-captcha/includes/core.php
+++ b/friendly-captcha/includes/core.php
@@ -19,7 +19,8 @@
         public static $option_group = "frcaptcha_options";
         public static $option_sitekey_name = "frcaptcha_sitekey";
         public static $option_api_key_name = "frcaptcha_api_key";
-        public static $option_skip_style_injection = "frcaptcha_skip_style_injection";
+        public static $option_skip_style_injection_name = "frcaptcha_skip_style_injection";
+        public static $option_enable_mutation_observer_name = "frcaptcha_enable_mutation_observer";
 
         // Integrations
         public static $option_contact_form_7_integration_active_name = "frcaptcha_contact_form_7_integration_active";
@@ -97,7 +98,11 @@
         }
 
         public function get_skip_style_injection() {
-            return get_option(FriendlyCaptcha_Plugin::$option_skip_style_injection) == 1;
+            return get_option(FriendlyCaptcha_Plugin::$option_skip_style_injection_name) == 1;
+        }
+
+        public function get_enable_mutation_observer() {
+            return get_option(FriendlyCaptcha_Plugin::$option_enable_mutation_observer_name) == 1;
         }
 
         public function get_contact_form_7_active() {

--- a/friendly-captcha/includes/settings.php
+++ b/friendly-captcha/includes/settings.php
@@ -584,12 +584,12 @@ if (is_admin()) {
 
         add_settings_field(
             'frcaptcha_settings_mutation_observer',
-            'Mutation Observer', 'frcaptcha_settings_field_callback',
+            'Dynamically Initialize', 'frcaptcha_settings_field_callback',
             'friendly_captcha_admin',
-            'frcaptcha_general_settings_section',
+            'frcaptcha_widget_settings_section',
             array(
                 "option_name" => FriendlyCaptcha_Plugin::$option_enable_mutation_observer_name,
-                "description" => "Enable to watch for changes in the DOM and setup widgets that are added later on.",
+                "description" => "Make Friendly Captcha look for new widgets that are dynamically added to the page.<br>Enable this when you are using Friendly Captcha in a popup or a multi-step form.",
                 "type" => "checkbox"
             )
         );

--- a/friendly-captcha/includes/settings.php
+++ b/friendly-captcha/includes/settings.php
@@ -16,7 +16,11 @@ if (is_admin()) {
         );
         register_setting(
             FriendlyCaptcha_Plugin::$option_group,
-            FriendlyCaptcha_Plugin::$option_skip_style_injection
+            FriendlyCaptcha_Plugin::$option_skip_style_injection_name
+        );
+        register_setting(
+            FriendlyCaptcha_Plugin::$option_group,
+            FriendlyCaptcha_Plugin::$option_enable_mutation_observer_name
         );
 
         register_setting(
@@ -572,11 +576,24 @@ if (is_admin()) {
             'friendly_captcha_admin',
             'frcaptcha_widget_settings_section',
             array(
-                "option_name" => FriendlyCaptcha_Plugin::$option_skip_style_injection,
+                "option_name" => FriendlyCaptcha_Plugin::$option_skip_style_injection_name,
                 "description" => "Don't load the CSS-Styles for the widget. Use this if you want to style the widget yourself.",
                 "type" => "checkbox"
             )
         );
+
+        add_settings_field(
+            'frcaptcha_settings_mutation_observer',
+            'Mutation Observer', 'frcaptcha_settings_field_callback',
+            'friendly_captcha_admin',
+            'frcaptcha_general_settings_section',
+            array(
+                "option_name" => FriendlyCaptcha_Plugin::$option_enable_mutation_observer_name,
+                "description" => "Enable to watch for changes in the DOM and setup widgets that are added later on.",
+                "type" => "checkbox"
+            )
+        );
+
 
         /* Endpoint section */
 

--- a/friendly-captcha/public/mutation-observer.js
+++ b/friendly-captcha/public/mutation-observer.js
@@ -1,26 +1,30 @@
 (function () {
   function findCaptchaElements(node) {
-    return parent.querySelectorAll(".frc-captcha");
+    return document.body.querySelectorAll(".frc-captcha");
   }
 
   function setupCaptchaElements(node) {
+    if (!window.friendlyChallenge) return;
+
     let autoWidget = window.friendlyChallenge.autoWidget;
 
     const elements = findCaptchaElements(node);
     for (let index = 0; index < elements.length; index++) {
       const hElement = elements[index];
-      if (hElement && !hElement.dataset["attached"]) {
+
+      // friendly-challenge adds the "friendlyChallengeWidget" property to the element when it's initialized
+      if (hElement && !hElement.friendlyChallengeWidget) {
         autoWidget = new window.friendlyChallenge.WidgetInstance(hElement);
-        // We set the "data-attached" attribute so we don't attach to the same element twice.
-        hElement.dataset["attached"] = "1";
       }
     }
+
     window.friendlyChallenge.autoWidget = autoWidget;
   }
 
   const observer = new MutationObserver((mutationList) => {
     for (const mutation of mutationList) {
       if (mutation.type === "childList") {
+        // We only care about new nodes being added
         for (const node of mutation.addedNodes) {
           setupCaptchaElements(node);
         }

--- a/friendly-captcha/public/mutation-observer.js
+++ b/friendly-captcha/public/mutation-observer.js
@@ -1,10 +1,13 @@
 (function () {
   function findCaptchaElements(node) {
-    return document.body.querySelectorAll(".frc-captcha");
+    return node.querySelectorAll(".frc-captcha");
   }
 
   function setupCaptchaElements(node) {
-    if (!window.friendlyChallenge) return;
+    if (!window.friendlyChallenge) {
+      // The friendly-challenge library has not been loaded yet
+      return;
+    }
 
     let autoWidget = window.friendlyChallenge.autoWidget;
 
@@ -32,7 +35,7 @@
     }
   });
 
-  // Start observing the target node for configured mutations
+  // Start observing the document body for changes
   observer.observe(document.body, {
     attributes: false,
     childList: true,

--- a/friendly-captcha/public/mutation-observer.js
+++ b/friendly-captcha/public/mutation-observer.js
@@ -12,8 +12,8 @@
     let autoWidget = window.friendlyChallenge.autoWidget;
 
     const elements = findCaptchaElements(node);
-    for (let index = 0; index < elements.length; index++) {
-      const hElement = elements[index];
+    for (let i = 0; i < elements.length; i++) {
+      const hElement = elements[i];
 
       // friendly-challenge adds the "friendlyChallengeWidget" property to the element when it's initialized
       if (hElement && !hElement.friendlyChallengeWidget) {
@@ -25,11 +25,15 @@
   }
 
   const observer = new MutationObserver((mutationList) => {
-    for (const mutation of mutationList) {
+    for (let m = 0; m < mutationList.length; m++) {
+      const mutation = mutationList[m];
+
       if (mutation.type === "childList") {
         // We only care about new nodes being added
-        for (const node of mutation.addedNodes) {
-          setupCaptchaElements(node);
+        const nodes = mutation.addedNodes;
+
+        for (let n = 0; n < nodes.length; n++) {
+          setupCaptchaElements(nodes[n]);
         }
       }
     }

--- a/friendly-captcha/public/mutation-observer.js
+++ b/friendly-captcha/public/mutation-observer.js
@@ -1,0 +1,37 @@
+(function () {
+  function findCaptchaElements(node) {
+    return parent.querySelectorAll(".frc-captcha");
+  }
+
+  function setupCaptchaElements(node) {
+    let autoWidget = window.friendlyChallenge.autoWidget;
+
+    const elements = findCaptchaElements(node);
+    for (let index = 0; index < elements.length; index++) {
+      const hElement = elements[index];
+      if (hElement && !hElement.dataset["attached"]) {
+        autoWidget = new window.friendlyChallenge.WidgetInstance(hElement);
+        // We set the "data-attached" attribute so we don't attach to the same element twice.
+        hElement.dataset["attached"] = "1";
+      }
+    }
+    window.friendlyChallenge.autoWidget = autoWidget;
+  }
+
+  const observer = new MutationObserver((mutationList) => {
+    for (const mutation of mutationList) {
+      if (mutation.type === "childList") {
+        for (const node of mutation.addedNodes) {
+          setupCaptchaElements(node);
+        }
+      }
+    }
+  });
+
+  // Start observing the target node for configured mutations
+  observer.observe(document.body, {
+    attributes: false,
+    childList: true,
+    subtree: false,
+  });
+})();

--- a/friendly-captcha/public/widgets.php
+++ b/friendly-captcha/public/widgets.php
@@ -24,6 +24,15 @@ function frcaptcha_enqueue_widget_scripts() {
         $version,
         true
     );
+
+    if ( $plugin->get_enable_mutation_observer() ) {
+        wp_enqueue_script( 'friendly-captcha-mutation-observer',
+            plugin_dir_url( __FILE__ ) . 'mutation-observer.js',
+            array(),
+            $version,
+            true
+        );
+    }
 }
 
 /**


### PR DESCRIPTION
This PR introduces a new settings which allows our plugin to initialize widgets that are dynamically added to the page after load. This includes popups, multi-step forms and generally content loaded with AJAX.

We achieve this by adding a MutationObserver to the document body which looks for new nodes being added to the DOM. It then initializes any element with the `.frc-captcha` class if it doesn't have the `friendlyChallengeWidget` property which is added by the friendly-challenge library.
We look for the `friendlyChallengeWidget` property instead of the `data-attached` attribute because the latter persists when HTML is removed and added back to the DOM.

This is opt-in because it could potentially affect the performance of the page. After all we are running a bit of code whenever a new node is added to the DOM.

![grafik](https://github.com/FriendlyCaptcha/friendly-captcha-wordpress/assets/33966852/2c22d92c-b4e1-4554-9ebf-c5d2b6001bbb)
