### PR TITLE
Fix deprecation error in PHP 8.1 and above

### DIFF
--- a/friendly-captcha/friendly-captcha.php
+++ b/friendly-captcha/friendly-captcha.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Friendly Captcha for WordPress
  * Description: Protect WordPress website forms from spam and abuse with Friendly Captcha, a privacy-first anti-bot solution.
- * Version: 1.12.1
+ * Version: 1.12.2
  * Requires at least: 5.0
  * Requires PHP: 7.3
  * Author: Friendly Captcha GmbH
@@ -19,7 +19,7 @@ if (!defined('WPINC')) {
 	die;
 }
 
-define('FRIENDLY_CAPTCHA_VERSION', '1.12.1');
+define('FRIENDLY_CAPTCHA_VERSION', '1.12.2');
 define('FRIENDLY_CAPTCHA_FRIENDLY_CHALLENGE_VERSION', '0.9.12');
 define('FRIENDLY_CAPTCHA_SUPPORTED_LANGUAGES', [
 	"en" => "English",

--- a/friendly-captcha/includes/core.php
+++ b/friendly-captcha/includes/core.php
@@ -250,7 +250,7 @@
     }
 
     // This creates the singleton instance
-    if ( !defined(FriendlyCaptcha_Plugin::$instance)) {
+    if ( !isset(FriendlyCaptcha_Plugin::$instance)) {
         $frcaptcha_plugin_instance = new FriendlyCaptcha_Plugin();
         $frcaptcha_plugin_instance->init();
     }

--- a/friendly-captcha/readme.txt
+++ b/friendly-captcha/readme.txt
@@ -4,7 +4,7 @@ Tags: captcha, antispam, spam, contact form, recaptcha, friendly-captcha, block 
 Requires at least: 5.0
 Tested up to: 6.3
 Requires PHP: 7.3
-Stable tag: 1.12.1
+Stable tag: 1.12.2
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -93,6 +93,9 @@ If you see an integration that's missing, please [open a pull request](https://g
 However, you may wish to email the authors of plugins you'd like to support Friendly Captcha: it will usually take them only an hour or two to add native support if they choose to do so. This will simplify your use of Friendly Captcha, and is the best solution in the long run.
 
 == Changelog ==
+
+= 1.12.2 =
+* Support for PHP 8.1
 
 = 1.12.1 =
 * Support widgets that are dynamically added to the page (e.g. popups or multi-step forms)


### PR DESCRIPTION
With PHP 8.1 passing null to inbuilt functions is deprecated. See https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg

We have previously used `defined` to check if the singleton instance of our plugin class has already been created. `defined` expects a string and is not meant to be used for checking if a variable is set. 

In practice this has probably caused the check to always return false and the class to be recreated every time. We just never noticed because before PHP 8.1 this was just ignored.