### PR TITLE
Reset widgets after submission in contact form 7, WPForms & Elementor

### DIFF
--- a/friendly-captcha/modules/contact-form-7/script.js
+++ b/friendly-captcha/modules/contact-form-7/script.js
@@ -1,16 +1,12 @@
-(function() {
-    var resetFriendlyCaptchaWidget = function() {
-        window.friendlyChallenge.autoWidget.reset();
-    }
-	document.addEventListener( 'DOMContentLoaded', function( event ) {
-        document.addEventListener( 'wpcf7mailsent',
-            resetFriendlyCaptchaWidget
-        );
-        document.addEventListener( 'wpcf7mailfailed',
-            resetFriendlyCaptchaWidget
-		);
-        document.addEventListener( 'wpcf7spam',
-            resetFriendlyCaptchaWidget
-        );
-    });
+(function () {
+  var resetFriendlyCaptchaWidget = function () {
+    window.friendlyChallenge.autoWidget.reset();
+  };
+  document.addEventListener("DOMContentLoaded", function (event) {
+    document.addEventListener("wpcf7mailsent", resetFriendlyCaptchaWidget);
+    document.addEventListener("wpcf7mailfailed", resetFriendlyCaptchaWidget);
+    document.addEventListener("wpcf7spam", resetFriendlyCaptchaWidget);
+    document.addEventListener("wpcf7invalid", resetFriendlyCaptchaWidget);
+    document.addEventListener("wpcf7submit", resetFriendlyCaptchaWidget);
+  });
 })();

--- a/friendly-captcha/modules/elementor/field.php
+++ b/friendly-captcha/modules/elementor/field.php
@@ -43,6 +43,15 @@ class Elementor_Form_Friendlycaptcha_Field extends \ElementorPro\Modules\Forms\F
         
 		echo frcaptcha_generate_widget_tag_from_plugin($plugin);
         frcaptcha_enqueue_widget_scripts();
+
+		wp_enqueue_script(
+			'frcaptcha_elementor-friendly-captcha',
+			plugin_dir_url(__FILE__) . 'script.js',
+			array('friendly-captcha-widget-module', 'friendly-captcha-widget-fallback'),
+			FriendlyCaptcha_Plugin::$version,
+			true
+		);
+
         echo "<style>.frc-captcha {max-width: 100%; width:100%}</style>";
 
         // We render a hidden field so Elementor knows where to display errors

--- a/friendly-captcha/modules/elementor/script.js
+++ b/friendly-captcha/modules/elementor/script.js
@@ -1,0 +1,25 @@
+(function () {
+  document.addEventListener("submit", function (e) {
+    const form = e.submitter.closest("form");
+    if (!form) {
+      return;
+    }
+
+    const element = form.querySelector(".frc-captcha");
+    if (!element) {
+      return;
+    }
+
+    const widget = element.friendlyChallengeWidget;
+    if (!widget) {
+      return;
+    }
+
+    setTimeout(() => {
+      // We reset the widget after a short delay to give the form time to grab the solution and submit it
+      // This is a workaround for the fact that the form submit event is fired before the solution value is grabbed
+      // 1 second is really conservative as this is not affected by network speed or anything like that
+      widget.reset();
+    }, 1000);
+  });
+})();

--- a/friendly-captcha/modules/wpforms/script.js
+++ b/friendly-captcha/modules/wpforms/script.js
@@ -1,0 +1,28 @@
+(($) => {
+  function submitWidgetInForm(form) {
+    const elements = form.find(".frc-captcha");
+    if (!elements) {
+      return;
+    }
+
+    elements.each((_, e) => {
+      const widget = e.friendlyChallengeWidget;
+      console.log(widget);
+      if (!widget) {
+        return;
+      }
+
+      widget.reset();
+    });
+  }
+
+  $("form.wpforms-form").on(
+    "wpformsAjaxSubmitSuccess wpformsAjaxSubmitFailed",
+    (event) => {
+      const form = $(event.target);
+      if (form) {
+        submitWidgetInForm(form);
+      }
+    }
+  );
+})(jQuery);

--- a/friendly-captcha/modules/wpforms/wpforms.php
+++ b/friendly-captcha/modules/wpforms/wpforms.php
@@ -10,6 +10,10 @@ function frcaptcha_wpforms_friendly_captcha_enqueue_scripts() {
 
     frcaptcha_echo_script_tags();
 
+    // We add our own script to reset the widget after form submission
+    // wp_enqueue_script doesn't work with WPForms for some reason, so we have to echo the script tags manually.
+    echo '<script async defer src="'. plugin_dir_url( __FILE__ ) . 'script.js"></script>';
+
     // The CSS reset of WPForms is really agressive.. so we add the frcaptcha styles but more `!important`ly now.
     // Really wish this wasn't necessary..
     echo "<style>


### PR DESCRIPTION
Reset the widget after the form has been submitted (both successful or unsuccessful) so users can submit again. This was requested by customers because users were having problems resubmitting a form after the field validation has failed because the FC solution has already been used.

The script used for elementor can potentially used for any form plugin that doesn't prevent the default submit event. (wpforms does prevent it) I only tested it with elementor and it might somehow break other form plugins tho

I'm not entirely sure if this should be default behavior or opt in as it might lead to more spam submissions. What do you think @gzuidhof?