### PR TITLE
Move gitignore to root folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ node_modules/
 *.sqlite
 
 .DS_Store
+
+vendor/
+bin/

--- a/friendly-captcha/.gitignore
+++ b/friendly-captcha/.gitignore
@@ -1,2 +1,0 @@
-/vendor
-/bin


### PR DESCRIPTION
With the `.gitignore` moved to the root folder the vendor folder is still ignored from our version control but won't be ignored after installing the plugin (which only includes the `friendly-captcha` folder) into a Wordpress site. This way users can have their Wordpress site in version control together with all the dependencies. 

fixes #128