### PR TITLE
Don't call siteverify when Captcha solution is empty

### DIFF
--- a/friendly-captcha/friendly-captcha.php
+++ b/friendly-captcha/friendly-captcha.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Friendly Captcha for WordPress
  * Description: Protect WordPress website forms from spam and abuse with Friendly Captcha, a privacy-first anti-bot solution.
- * Version: 1.15.0
+ * Version: 1.15.1
  * Requires at least: 5.0
  * Requires PHP: 7.3
  * Author: Friendly Captcha GmbH
@@ -19,7 +19,7 @@ if (!defined('WPINC')) {
 	die;
 }
 
-define('FRIENDLY_CAPTCHA_VERSION', '1.15.0');
+define('FRIENDLY_CAPTCHA_VERSION', '1.15.1');
 define('FRIENDLY_CAPTCHA_FRIENDLY_CHALLENGE_VERSION', '0.9.12');
 define('FRIENDLY_CAPTCHA_FRIENDLY_CAPTCHA_SDK_VERSION', '0.1.7');
 define('FRIENDLY_CAPTCHA_SUPPORTED_LANGUAGES', [

--- a/friendly-captcha/includes/core.php
+++ b/friendly-captcha/includes/core.php
@@ -31,7 +31,7 @@ class FriendlyCaptcha_Plugin
     public static $option_global_puzzle_endpoint_active_name = "frcaptcha_global_endpoint_active";
     public static $option_eu_puzzle_endpoint_active_name = "frcaptcha_eu_endpoint_active";
 
-    public static $option_verification_failed_alert_name = "frcaptcha_verification_failed_alert";
+    public static $option_verification_failed_alert_name = "frcaptcha_verification_failed_alert_v2";
 
     public static $integrations = array(
         array(

--- a/friendly-captcha/modules/divi/frcaptcha_divi_core_addon.php
+++ b/friendly-captcha/modules/divi/frcaptcha_divi_core_addon.php
@@ -1,85 +1,94 @@
 <?php
 
-class frcaptcha_divi_core_addon extends ET_Core_API_Spam_Provider {
-	public $name = 'FriendlyCaptcha';
+class frcaptcha_divi_core_addon extends ET_Core_API_Spam_Provider
+{
+    public $name = 'FriendlyCaptcha';
 
     /**
-	 * @inheritDoc
-	 */
-	public $slug = 'frcaptcha';
+     * @inheritDoc
+     */
+    public $slug = 'frcaptcha';
 
-	public $custom_fields = null; // avoid notice from \ET_Core_API_Email_Providers::_initialize which expects this field
+    public $custom_fields = null; // avoid notice from \ET_Core_API_Email_Providers::_initialize which expects this field
 
-	public function __construct( $owner = 'frcaptcha', $account_name = '', $api_key = '' ) {
-		parent::__construct( $owner, $account_name, $api_key );
+    public function __construct($owner = 'frcaptcha', $account_name = '', $api_key = '')
+    {
+        parent::__construct($owner, $account_name, $api_key);
 
-		$this->_add_actions_and_filters();
-	}
+        $this->_add_actions_and_filters();
+    }
 
-	protected function _add_actions_and_filters() {
-		if ( ! is_admin() && ! et_core_is_fb_enabled() ) {
-			add_action( 'wp_enqueue_scripts', array( $this, 'action_wp_enqueue_scripts' ) );
-		}
-	}
+    protected function _add_actions_and_filters()
+    {
+        if (!is_admin() && !et_core_is_fb_enabled()) {
+            add_action('wp_enqueue_scripts', array($this, 'action_wp_enqueue_scripts'));
+        }
+    }
 
-	public function action_wp_enqueue_scripts() {
+    public function action_wp_enqueue_scripts()
+    {
         $plugin = FriendlyCaptcha_Plugin::$instance;
 
-        if ( !$plugin->is_configured() ) {
+        if (!$plugin->is_configured()) {
             return;
         }
 
-		if ( ! $this->is_enabled() ) {
-			return;
-		}
+        if (!$this->is_enabled()) {
+            return;
+        }
 
         frcaptcha_enqueue_widget_scripts(true);
 
         wp_dequeue_script('et-core-api-spam-recaptcha');
-	}
+    }
 
-    public function is_enabled() {
+    public function is_enabled()
+    {
         $has_frcaptcha_module = true;
 
-        if ( class_exists( 'ET_Dynamic_Assets' ) ) {
+        if (class_exists('ET_Dynamic_Assets')) {
             $et_dynamic_module_framework  = et_builder_dynamic_module_framework();
             $is_dynamic_framework_enabled = et_builder_is_frontend() && 'on' === $et_dynamic_module_framework;
             $is_dynamic_css_enabled       = et_builder_is_frontend() && et_use_dynamic_css();
 
-            if ( $is_dynamic_framework_enabled && $is_dynamic_css_enabled ) {
+            if ($is_dynamic_framework_enabled && $is_dynamic_css_enabled) {
                 $et_dynamic_assets    = ET_Dynamic_Assets::init();
                 $saved_shortcodes     = $et_dynamic_assets->get_saved_page_shortcodes();
-                $frcaptcha_modules    = array( 'et_pb_contact_form', 'et_pb_signup' );
-                $has_frcaptcha_module = ! empty( array_intersect( $saved_shortcodes, $frcaptcha_modules ) );
+                $frcaptcha_modules    = array('et_pb_contact_form', 'et_pb_signup');
+                $has_frcaptcha_module = !empty(array_intersect($saved_shortcodes, $frcaptcha_modules));
             }
         }
 
         return $has_frcaptcha_module;
     }
 
-	public function verify_form_submission() {
+    public function verify_form_submission()
+    {
         $plugin = FriendlyCaptcha_Plugin::$instance;
 
-        if ( !$plugin->is_configured() ) {
+        if (!$plugin->is_configured()) {
             return array(
                 'success' => true,
                 'score' => 100000,
             );
         }
 
-        if ( ! $this->is_enabled() ) {
+        if (!$this->is_enabled()) {
             return array(
                 'success' => true,
                 'score' => 100000,
             );
         }
 
-        $solution = et_()->array_get_sanitized( $_POST, 'token' );
+        $solution = et_()->array_get_sanitized($_POST, 'token');
+        if (empty($solution)) {
+            return 'Captcha missing';
+        }
 
         $plugin = FriendlyCaptcha_Plugin::$instance;
         $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
 
-        if ( $verification["success"] ) {
+        if ($verification["success"]) {
             return array(
                 'success' => true,
                 'score' => 100000,
@@ -87,9 +96,10 @@ class frcaptcha_divi_core_addon extends ET_Core_API_Spam_Provider {
         } else {
             return 'Captcha error';
         }
-	}
+    }
 
-	public function get_account_fields() {
-		return array();
-	}
+    public function get_account_fields()
+    {
+        return array();
+    }
 }

--- a/friendly-captcha/modules/formidable/FrcaptchaFieldNewType.php
+++ b/friendly-captcha/modules/formidable/FrcaptchaFieldNewType.php
@@ -86,6 +86,7 @@ class FrcaptchaFieldNewType extends FrmFieldType
 
 		if (empty($solution)) {
 			$errors['field' . $args['id']] = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message();
+			return $errors;
 		}
 
 		$verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());

--- a/friendly-captcha/modules/profile-builder/profile_builder_login.php
+++ b/friendly-captcha/modules/profile-builder/profile_builder_login.php
@@ -31,6 +31,7 @@ function frcaptcha_pb_login_validate($user)
             $user = new WP_Error('wpbb_recaptcha_error', FriendlyCaptcha_Plugin::default_error_user_message() . __(' (captcha missing)', 'frcaptcha'));
             remove_filter('authenticate', 'wp_authenticate_username_password', 20, 3);
             remove_filter('authenticate', 'wp_authenticate_email_password', 20, 3);
+            return;
         }
 
         $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());

--- a/friendly-captcha/modules/profile-builder/profile_builder_register.php
+++ b/friendly-captcha/modules/profile-builder/profile_builder_register.php
@@ -31,6 +31,7 @@ function frcaptcha_pb_register_validate($output_field_errors, $form_fields, $glo
     //    We need to use a field id in the array. Because we don't have such id we just use a high number that will never be used by the plugin itself.
     if (empty($solution)) {
         $output_field_errors[100] = '<span class="wppb-form-error">' . FriendlyCaptcha_Plugin::default_error_user_message() .  __(' (captcha missing)', 'frcaptcha') . '</span>';
+        return;
     }
 
     $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());

--- a/friendly-captcha/modules/profile-builder/profile_builder_reset_password.php
+++ b/friendly-captcha/modules/profile-builder/profile_builder_reset_password.php
@@ -28,6 +28,7 @@ function frcaptcha_pb_reset_password_sent_message($message)
 
     if (empty($solution)) {
         $message = 'wppb_recaptcha_error';
+        return $message;
     }
 
     $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());

--- a/friendly-captcha/modules/woocommerce/woocommerce_checkout.php
+++ b/friendly-captcha/modules/woocommerce/woocommerce_checkout.php
@@ -37,6 +37,7 @@ function frcaptcha_wc_checkout_validate()
     if (empty($solution)) {
         $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message() . __(' (captcha missing)', 'frcaptcha');
         wc_add_notice($error_message, 'error');
+        return;
     }
 
     $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());

--- a/friendly-captcha/modules/woocommerce/woocommerce_login.php
+++ b/friendly-captcha/modules/woocommerce/woocommerce_login.php
@@ -41,6 +41,7 @@ function frcaptcha_wc_login_validate($validation_error)
     if (empty($solution)) {
         $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message() . __(' (captcha missing)', 'frcaptcha');
         $validation_error->add('frcaptcha-empty-error', $error_message);
+        return $validation_error;
     }
 
     $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());

--- a/friendly-captcha/modules/woocommerce/woocommerce_register.php
+++ b/friendly-captcha/modules/woocommerce/woocommerce_register.php
@@ -37,6 +37,7 @@ function frcaptcha_wc_register_validate($validation_error)
     if (empty($solution)) {
         $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message() . __(' (captcha missing)', 'frcaptcha');
         $validation_error->add('frcaptcha-empty-error', $error_message);
+        return $validation_error;
     }
 
     $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());

--- a/friendly-captcha/modules/wpforms/wpforms.php
+++ b/friendly-captcha/modules/wpforms/wpforms.php
@@ -196,6 +196,7 @@ function frcaptcha_wpforms_process($fields, $entry, $form_data)
                 'form_id' => $form_data['id'],
             )
         );
+        return;
     }
 
     $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());

--- a/friendly-captcha/readme.txt
+++ b/friendly-captcha/readme.txt
@@ -4,7 +4,7 @@ Tags: captcha, antispam, spam, contact form, recaptcha, friendly-captcha, block 
 Requires at least: 5.0
 Tested up to: 6.5
 Requires PHP: 7.3
-Stable tag: 1.15.0
+Stable tag: 1.15.1
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -95,6 +95,10 @@ If you see an integration that's missing, please [open a pull request](https://g
 However, you may wish to email the authors of plugins you'd like to support Friendly Captcha: it will usually take them only an hour or two to add native support if they choose to do so. This will simplify your use of Friendly Captcha, and is the best solution in the long run.
 
 == Changelog ==
+
+= 1.15.1 =
+
+* Don't call siteverify endpoint when Captcha solution is empty
 
 = 1.15.0 =
 


### PR DESCRIPTION
This was already the case for most integrations, some were just missing an early return. Submitting them to the siteverify endpoint would return a non-200 response code and an unnecessary error alert.