### PR TITLE
Skip second call of authenticate filter when Wordfence 2FA is enabled

### DIFF
--- a/friendly-captcha/modules/wordpress/wordpress_login.php
+++ b/friendly-captcha/modules/wordpress/wordpress_login.php
@@ -25,6 +25,13 @@ function frcaptcha_wp_login_validate($user, $username, $password)
         return $user;
     }
 
+    // When 2FA is configured using Wordfence, the filter is run twice. We want to skip the second run.
+    // See https://github.com/wordpress-premium/wordfence/blob/master/modules/login-security/classes/controller/wordfencels.php#L568
+    $is2FA = (defined('WORDFENCE_LS_AUTHENTICATION_CHECK') && WORDFENCE_LS_AUTHENTICATION_CHECK);
+    if ($is2FA) {
+        return $user;
+    }
+
     $plugin = FriendlyCaptcha_Plugin::$instance;
     if (!$plugin->is_configured()) {
         return $user;


### PR DESCRIPTION
The Wordfence code is a bit hard to follow, but I tried the positive and negative cases and it behaves as expected now. 

One other thing I noticed is that our `authenticate` filter is run after the credentials have been verified. I believe we should try to change it so the Captcha is verified before the credentials, right?

closes #144