### PR TITLE
Verify captcha before user password in Wordpress login

### DIFF
--- a/friendly-captcha/modules/wordpress/wordpress_login.php
+++ b/friendly-captcha/modules/wordpress/wordpress_login.php
@@ -25,6 +25,13 @@ function frcaptcha_wp_login_validate($user, $username, $password)
         return $user;
     }
 
+    // When 2FA is configured using Wordfence, the filter is run twice. We want to skip the second run.
+    // See https://github.com/wordpress-premium/wordfence/blob/master/modules/login-security/classes/controller/wordfencels.php#L568
+    $is2FA = (defined('WORDFENCE_LS_AUTHENTICATION_CHECK') && WORDFENCE_LS_AUTHENTICATION_CHECK);
+    if ($is2FA) {
+        return $user;
+    }
+
     $plugin = FriendlyCaptcha_Plugin::$instance;
     if (!$plugin->is_configured()) {
         return $user;

--- a/friendly-captcha/modules/wordpress/wordpress_login.php
+++ b/friendly-captcha/modules/wordpress/wordpress_login.php
@@ -17,9 +17,9 @@ function frcaptcha_wp_login_show_widget()
     frcaptcha_enqueue_widget_scripts();
 }
 
-add_filter('authenticate', 'frcaptcha_wp_login_validate', 20, 3);
+add_filter('wp_authenticate_user', 'frcaptcha_wp_login_validate', 20, 2);
 
-function frcaptcha_wp_login_validate($user, $username, $password)
+function frcaptcha_wp_login_validate($user, $password)
 {
     if ($user instanceof WP_Error) {
         return $user;


### PR DESCRIPTION
Previously the captcha was verified using the `authenticate` filter which only runs when the username and password are correct. The `wp_authenticate_user` is run after the username but before the password is verified which is exactly what we need.

The more obvious solution would have been to decrease the priority of our `authenticate` filter so it runs before the default WordPress ones. This doesn't work in practice because the default WordPress filters don't exit early when a previous filter returns an error. 

See https://github.com/WordPress/wordpress-develop/blob/6.7/src/wp-includes/user.php#L153-L218