### PR TITLE
Remove the correct filter when using Ultimate Member

### DIFF
--- a/friendly-captcha/friendly-captcha.php
+++ b/friendly-captcha/friendly-captcha.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Friendly Captcha for WordPress
  * Description: Protect WordPress website forms from spam and abuse with Friendly Captcha, a privacy-first anti-bot solution.
- * Version: 1.15.10
+ * Version: 1.15.11
  * Requires at least: 5.0
  * Requires PHP: 7.3
  * Author: Friendly Captcha GmbH
@@ -19,7 +19,7 @@ if (!defined('WPINC')) {
 	die;
 }
 
-define('FRIENDLY_CAPTCHA_VERSION', '1.15.10');
+define('FRIENDLY_CAPTCHA_VERSION', '1.15.11');
 define('FRIENDLY_CAPTCHA_FRIENDLY_CHALLENGE_VERSION', '0.9.18');
 define('FRIENDLY_CAPTCHA_FRIENDLY_CAPTCHA_SDK_VERSION', '0.1.10');
 define('FRIENDLY_CAPTCHA_SUPPORTED_LANGUAGES', [

--- a/friendly-captcha/modules/wordpress/wordpress_login.php
+++ b/friendly-captcha/modules/wordpress/wordpress_login.php
@@ -63,7 +63,7 @@ add_filter('um_submit_form_errors_hook_login', 'remove_filter_authenticate');
 
 function remove_filter_authenticate($credentials)
 {
-    remove_filter('authenticate', 'frcaptcha_wp_login_validate', 20);
+    remove_filter('wp_authenticate_user', 'frcaptcha_wp_login_validate', 20);
 
     return $credentials;
 }

--- a/friendly-captcha/readme.txt
+++ b/friendly-captcha/readme.txt
@@ -96,6 +96,10 @@ However, you may wish to email the authors of plugins you'd like to support Frie
 
 == Changelog ==
 
+= 1.15.11 =
+
+* Fix bug that caused the Ultimate Member integration to verify response twice
+
 = 1.15.10 =
 
 * Fix form validation bug in Profile Builder register page


### PR DESCRIPTION
We changed the filter for WordPress Login from 'authenticate' to 'wp_authenticate_user'. We need to also update the logic that removes that filter when Ultimate Member is in use; otherwise the verification method call happens twice. The second time it fails with `response_duplicate`.