### PR TITLE
Enqueue friendly captcha scripts on elementor init

### DIFF
--- a/friendly-captcha/friendly-captcha.php
+++ b/friendly-captcha/friendly-captcha.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Friendly Captcha for WordPress
  * Description: Protect WordPress website forms from spam and abuse with Friendly Captcha, a privacy-first anti-bot solution.
- * Version: 1.15.12
+ * Version: 1.15.13
  * Requires at least: 5.0
  * Requires PHP: 7.3
  * Author: Friendly Captcha GmbH
@@ -19,7 +19,7 @@ if (!defined('WPINC')) {
 	die;
 }
 
-define('FRIENDLY_CAPTCHA_VERSION', '1.15.12');
+define('FRIENDLY_CAPTCHA_VERSION', '1.15.13');
 define('FRIENDLY_CAPTCHA_FRIENDLY_CHALLENGE_VERSION', '0.9.18');
 define('FRIENDLY_CAPTCHA_FRIENDLY_CAPTCHA_SDK_VERSION', '0.1.10');
 define('FRIENDLY_CAPTCHA_SUPPORTED_LANGUAGES', [

--- a/friendly-captcha/modules/elementor/elementor.php
+++ b/friendly-captcha/modules/elementor/elementor.php
@@ -2,7 +2,20 @@
 
 // https://developers.elementor.com/docs/form-fields/add-new-field/
 
-function frcaptcha_add_form_field($form_fields_registrar)
+function frcaptcha_elementor_init()
+{
+    frcaptcha_enqueue_widget_scripts();
+
+    wp_enqueue_script(
+        'frcaptcha_elementor-friendly-captcha',
+        plugin_dir_url(__FILE__) . 'script.js',
+        array('friendly-captcha-widget-module', 'friendly-captcha-widget-fallback'),
+        FriendlyCaptcha_Plugin::$version,
+        true
+    );
+}
+
+function frcaptcha_elementor_add_form_field($form_fields_registrar)
 {
     $plugin = FriendlyCaptcha_Plugin::$instance;
     if (!$plugin->is_configured()) {
@@ -14,4 +27,5 @@ function frcaptcha_add_form_field($form_fields_registrar)
     $form_fields_registrar->register(new \Elementor_Form_Friendlycaptcha_Field());
 }
 
-add_action('elementor_pro/forms/fields/register', 'frcaptcha_add_form_field');
+add_action('elementor/init', 'frcaptcha_elementor_init');
+add_action('elementor_pro/forms/fields/register', 'frcaptcha_elementor_add_form_field');

--- a/friendly-captcha/modules/elementor/field.php
+++ b/friendly-captcha/modules/elementor/field.php
@@ -46,15 +46,6 @@ class Elementor_Form_Friendlycaptcha_Field extends \ElementorPro\Modules\Forms\F
 		}
 
 		echo frcaptcha_generate_widget_tag_from_plugin($plugin);
-		frcaptcha_enqueue_widget_scripts();
-
-		wp_enqueue_script(
-			'frcaptcha_elementor-friendly-captcha',
-			plugin_dir_url(__FILE__) . 'script.js',
-			array('friendly-captcha-widget-module', 'friendly-captcha-widget-fallback'),
-			FriendlyCaptcha_Plugin::$version,
-			true
-		);
 
 		echo "<style>.frc-captcha {max-width: 100%; width:100%}</style>";
 

--- a/friendly-captcha/readme.txt
+++ b/friendly-captcha/readme.txt
@@ -4,7 +4,7 @@ Tags: captcha, antispam, spam, contact form, recaptcha, friendly-captcha, block 
 Requires at least: 5.0
 Tested up to: 6.5
 Requires PHP: 7.3
-Stable tag: 1.15.12
+Stable tag: 1.15.13
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -96,7 +96,7 @@ However, you may wish to email the authors of plugins you'd like to support Frie
 
 == Changelog ==
 
-= 1.15.12 =
+= 1.15.13 =
 
 * Fix bug that caused the Ultimate Member integration to verify response twice
 


### PR DESCRIPTION
I suspect that the `render` method of a custom Elementor field is only called once and then the result is cached which leads to the weird behavior where Friendly Captcha loads in some cases but doesn't in others.
I have moved the enqueuing of the Friendly Captcha scripts to the `elementor/init` hook which should always be called. This also means the Friendly Captcha scripts are loaded on every page using Elementor but I think that's OK. [hCaptcha does the same.](https://github.com/hCaptcha/hcaptcha-wordpress-plugin/blob/master/src/php/ElementorPro/HCaptchaHandler.php#L84-L113)

#139