### PR TITLE
Add support for passing "Frc-Sdk" header

### DIFF
--- a/friendly-captcha/composer.json
+++ b/friendly-captcha/composer.json
@@ -1,5 +1,5 @@
 {
   "require": {
-    "friendlycaptcha/sdk": "^0.1.0"
+    "friendlycaptcha/sdk": "^0.1.2"
   }
 }

--- a/friendly-captcha/composer.lock
+++ b/friendly-captcha/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "99b38aed28d5e7d272cd1e39485931a4",
+    "content-hash": "abf157cf28eb088e74a14c026749e730",
     "packages": [
         {
             "name": "friendlycaptcha/sdk",
-            "version": "v0.1.0",
+            "version": "0.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendlyCaptcha/friendly-captcha-php.git",
-                "reference": "4883c22ee8b913fdf085d2ac236c6169e304e3ad"
+                "reference": "9cc23e800f36ba281d017f481b7d3a070a03d010"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendlyCaptcha/friendly-captcha-php/zipball/4883c22ee8b913fdf085d2ac236c6169e304e3ad",
-                "reference": "4883c22ee8b913fdf085d2ac236c6169e304e3ad",
+                "url": "https://api.github.com/repos/FriendlyCaptcha/friendly-captcha-php/zipball/9cc23e800f36ba281d017f481b7d3a070a03d010",
+                "reference": "9cc23e800f36ba281d017f481b7d3a070a03d010",
                 "shasum": ""
             },
             "require": {
@@ -46,18 +46,18 @@
             "description": "Serverside SDK for the Friendly Captcha API.",
             "support": {
                 "issues": "https://github.com/FriendlyCaptcha/friendly-captcha-php/issues",
-                "source": "https://github.com/FriendlyCaptcha/friendly-captcha-php/tree/v0.1.0"
+                "source": "https://github.com/FriendlyCaptcha/friendly-captcha-php/tree/0.1.2"
             },
-            "time": "2024-01-02T15:48:15+00:00"
+            "time": "2025-03-05T16:37:37+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/friendly-captcha/friendly-captcha.php
+++ b/friendly-captcha/friendly-captcha.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Friendly Captcha for WordPress
  * Description: Protect WordPress website forms from spam and abuse with Friendly Captcha, a privacy-first anti-bot solution.
- * Version: 1.15.13
+ * Version: 1.15.14
  * Requires at least: 5.0
  * Requires PHP: 7.3
  * Author: Friendly Captcha GmbH
@@ -19,7 +19,7 @@ if (!defined('WPINC')) {
 	die;
 }
 
-define('FRIENDLY_CAPTCHA_VERSION', '1.15.13');
+define('FRIENDLY_CAPTCHA_VERSION', '1.15.14');
 define('FRIENDLY_CAPTCHA_FRIENDLY_CHALLENGE_VERSION', '0.9.18');
 define('FRIENDLY_CAPTCHA_FRIENDLY_CAPTCHA_SDK_VERSION', '0.1.10');
 define('FRIENDLY_CAPTCHA_SUPPORTED_LANGUAGES', [

--- a/friendly-captcha/includes/verification.php
+++ b/friendly-captcha/includes/verification.php
@@ -2,16 +2,21 @@
 
 use FriendlyCaptcha\SDK\{Client, ClientConfig};
 
-function frcaptcha_verify_captcha_solution($solution, $sitekey, $api_key)
+function frcaptcha_verify_captcha_solution($solution, $sitekey, $api_key, $integration = null)
 {
+    $frcSdk = 'friendly-captcha-wordpress@' . FriendlyCaptcha_Plugin::$version;
+    if ($integration) {
+        $frcSdk = $frcSdk . "; " . $integration;
+    }
+
     if (FriendlyCaptcha_Plugin::$instance->get_enable_v2()) {
-        return frcaptcha_v2_verify_captcha_solution($solution, $sitekey, $api_key);
+        return frcaptcha_v2_verify_captcha_solution($solution, $sitekey, $api_key, $frcSdk);
     } else {
-        return frcaptcha_v1_verify_captcha_solution($solution, $sitekey, $api_key);
+        return frcaptcha_v1_verify_captcha_solution($solution, $sitekey, $api_key, $frcSdk);
     }
 }
 
-function frcaptcha_v1_verify_captcha_solution($solution, $sitekey, $api_key)
+function frcaptcha_v1_verify_captcha_solution($solution, $sitekey, $api_key, $frcSdk)
 {
     $endpoint = 'https://api.friendlycaptcha.com/api/v1/siteverify';
     if (FriendlyCaptcha_Plugin::$instance->get_eu_puzzle_endpoint_active()) {
@@ -24,8 +29,13 @@ function frcaptcha_v1_verify_captcha_solution($solution, $sitekey, $api_key)
         'solution' => $solution,
     );
 
+    $request_headers = array(
+        'Frc-Sdk' => $frcSdk,
+    );
+
     $request = array(
         'body' => $request_body,
+        'headers' => $request_headers,
     );
 
     $response = wp_remote_post(esc_url_raw($endpoint), $request);
@@ -76,10 +86,10 @@ function frcaptcha_v1_verify_captcha_solution($solution, $sitekey, $api_key)
     );
 }
 
-function frcaptcha_v2_verify_captcha_solution($solution, $sitekey, $api_key)
+function frcaptcha_v2_verify_captcha_solution($solution, $sitekey, $api_key, $frcSdk)
 {
     $config = new ClientConfig();
-    $config->setAPIKey($api_key)->setSitekey($sitekey);
+    $config->setAPIKey($api_key)->setSitekey($sitekey)->setSDKTrailer($frcSdk);
     if (FriendlyCaptcha_Plugin::$instance->get_eu_puzzle_endpoint_active()) {
         $config->setSiteverifyEndpoint("eu");
     }

--- a/friendly-captcha/includes/verification.php
+++ b/friendly-captcha/includes/verification.php
@@ -4,19 +4,19 @@ use FriendlyCaptcha\SDK\{Client, ClientConfig};
 
 function frcaptcha_verify_captcha_solution($solution, $sitekey, $api_key, $integration = null)
 {
-    $frcSdk = 'friendly-captcha-wordpress@' . FriendlyCaptcha_Plugin::$version;
-    if ($integration) {
-        $frcSdk = $frcSdk . "; " . $integration;
-    }
-
     if (FriendlyCaptcha_Plugin::$instance->get_enable_v2()) {
+        $frcSdk = 'friendly-captcha-wordpress@' . FriendlyCaptcha_Plugin::$version;
+        if ($integration) {
+            $frcSdk = $frcSdk . "; " . $integration;
+        }
+
         return frcaptcha_v2_verify_captcha_solution($solution, $sitekey, $api_key, $frcSdk);
     } else {
-        return frcaptcha_v1_verify_captcha_solution($solution, $sitekey, $api_key, $frcSdk);
+        return frcaptcha_v1_verify_captcha_solution($solution, $sitekey, $api_key);
     }
 }
 
-function frcaptcha_v1_verify_captcha_solution($solution, $sitekey, $api_key, $frcSdk)
+function frcaptcha_v1_verify_captcha_solution($solution, $sitekey, $api_key)
 {
     $endpoint = 'https://api.friendlycaptcha.com/api/v1/siteverify';
     if (FriendlyCaptcha_Plugin::$instance->get_eu_puzzle_endpoint_active()) {
@@ -29,13 +29,8 @@ function frcaptcha_v1_verify_captcha_solution($solution, $sitekey, $api_key, $fr
         'solution' => $solution,
     );
 
-    $request_headers = array(
-        'Frc-Sdk' => $frcSdk,
-    );
-
     $request = array(
         'body' => $request_body,
-        'headers' => $request_headers,
     );
 
     $response = wp_remote_post(esc_url_raw($endpoint), $request);

--- a/friendly-captcha/modules/avada-forms/avada-forms.php
+++ b/friendly-captcha/modules/avada-forms/avada-forms.php
@@ -42,7 +42,7 @@ function verify_friendly_captcha($demo_mode)
         die(wp_json_encode(['status' => 'error', 'info' => ['friendly_captcha' => $message]]));
     }
 
-    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'avada-forms');
 
     if (!$verification["success"]) {
         $message = FriendlyCaptcha_Plugin::default_error_user_message();

--- a/friendly-captcha/modules/coblocks/coblocks.php
+++ b/friendly-captcha/modules/coblocks/coblocks.php
@@ -116,7 +116,7 @@ class Frcaptcha_Coblocks
             ];
         }
 
-        $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+        $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'coblocks');
         if (!$verification["success"]) {
             // I haven't found a way to show a custom error message in the form, 
             // this is better than having no error message at all.

--- a/friendly-captcha/modules/contact-form-7/contact-form-7.php
+++ b/friendly-captcha/modules/contact-form-7/contact-form-7.php
@@ -80,7 +80,7 @@ function frcaptcha_wpcf7_friendly_captcha_verify_response($spam)
 		return true;
 	}
 
-	$verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+	$verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'contact-form-7');
 
 	if ($verification["success"]) {
 		$spam = false;

--- a/friendly-captcha/modules/divi/frcaptcha_divi_core_addon.php
+++ b/friendly-captcha/modules/divi/frcaptcha_divi_core_addon.php
@@ -86,7 +86,7 @@ class frcaptcha_divi_core_addon extends ET_Core_API_Spam_Provider
         }
 
         $plugin = FriendlyCaptcha_Plugin::$instance;
-        $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+        $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'divi');
 
         if ($verification["success"]) {
             return array(

--- a/friendly-captcha/modules/elementor/field.php
+++ b/friendly-captcha/modules/elementor/field.php
@@ -86,7 +86,7 @@ class Elementor_Form_Friendlycaptcha_Field extends \ElementorPro\Modules\Forms\F
 			return;
 		}
 
-		$verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+		$verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'elementor');
 
 		if (!$verification["success"]) {
 			$error_message = FriendlyCaptcha_Plugin::default_error_user_message();

--- a/friendly-captcha/modules/fluentform/fluentform.php
+++ b/friendly-captcha/modules/fluentform/fluentform.php
@@ -44,7 +44,7 @@ function frcaptcha_fluentform_validate($insert_data, $data, $form)
         );
     }
 
-    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'fluentform');
 
     if (!$verification["success"]) {
         $error_message = FriendlyCaptcha_Plugin::default_error_user_message();

--- a/friendly-captcha/modules/formidable/FrcaptchaFieldNewType.php
+++ b/friendly-captcha/modules/formidable/FrcaptchaFieldNewType.php
@@ -89,7 +89,7 @@ class FrcaptchaFieldNewType extends FrmFieldType
 			return $errors;
 		}
 
-		$verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+		$verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'formidable');
 
 		if (!$verification["success"]) {
 			$errors['field' . $args['id']] = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message();

--- a/friendly-captcha/modules/forminator/forminator.php
+++ b/friendly-captcha/modules/forminator/forminator.php
@@ -32,7 +32,7 @@ function frcaptcha_forminator_verify($can_show, $id, $form_settings)
 		];
 	}
 
-	$verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+	$verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'forminator');
 	if (!$verification["success"]) {
 		return [
 			'can_submit' => false,

--- a/friendly-captcha/modules/gravityforms/field.php
+++ b/friendly-captcha/modules/gravityforms/field.php
@@ -168,7 +168,7 @@ class GFForms_Friendlycaptcha_Field extends GF_Field
 			return;
 		}
 
-		$verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+		$verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'gravityforms');
 		if (!$verification["success"]) {
 			$this->failed_validation  = true;
 			$this->validation_message = FriendlyCaptcha_Plugin::default_error_user_message();

--- a/friendly-captcha/modules/html-forms/html-forms.php
+++ b/friendly-captcha/modules/html-forms/html-forms.php
@@ -25,7 +25,7 @@ add_filter('hf_validate_form', function ($error_code, $form, $data) {
         return 'frcaptcha_empty';
     }
 
-    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'html-forms');
 
     if (!$verification["success"]) {
         return 'frcaptcha_invalid';

--- a/friendly-captcha/modules/profile-builder/profile_builder_login.php
+++ b/friendly-captcha/modules/profile-builder/profile_builder_login.php
@@ -33,7 +33,7 @@ function frcaptcha_pb_login_validate($user)
             return new WP_Error('wpbb_recaptcha_error', FriendlyCaptcha_Plugin::default_error_user_message() . __(' (captcha missing)', 'frcaptcha'));
         }
 
-        $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+        $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'profile-builder');
         if (!$verification['success']) {
             remove_filter('authenticate', 'wp_authenticate_username_password', 20, 3);
             remove_filter('authenticate', 'wp_authenticate_email_password', 20, 3);

--- a/friendly-captcha/modules/profile-builder/profile_builder_register.php
+++ b/friendly-captcha/modules/profile-builder/profile_builder_register.php
@@ -44,7 +44,7 @@ function frcaptcha_pb_register_validate($output_field_errors, $form_fields, $glo
         return $output_field_errors;
     }
 
-    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'profile-builder');
     if (!$verification['success']) {
         $frcaptcha_pb_register_general_top_error_message_val = FriendlyCaptcha_Plugin::default_error_user_message();
         $output_field_errors = (array) $output_field_errors;

--- a/friendly-captcha/modules/profile-builder/profile_builder_reset_password.php
+++ b/friendly-captcha/modules/profile-builder/profile_builder_reset_password.php
@@ -30,7 +30,7 @@ function frcaptcha_pb_reset_password_sent_message($message)
         return 'wppb_recaptcha_error';
     }
 
-    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'profile-builder');
 
     if (!$verification['success']) {
         return 'wppb_recaptcha_error';

--- a/friendly-captcha/modules/ultimate-member/ultimate-member_login.php
+++ b/friendly-captcha/modules/ultimate-member/ultimate-member_login.php
@@ -36,7 +36,7 @@ function frcaptcha_um_login_validate($post, $form_data)
             return;
         }
 
-        $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+        $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'ultimate-member');
 
         if (!$verification['success']) {
             $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message();

--- a/friendly-captcha/modules/ultimate-member/ultimate-member_register.php
+++ b/friendly-captcha/modules/ultimate-member/ultimate-member_register.php
@@ -36,7 +36,7 @@ function frcaptcha_um_register_validate($post, $form_data)
             return;
         }
 
-        $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+        $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'ultimate-member');
 
         if (!$verification['success']) {
             $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message();

--- a/friendly-captcha/modules/ultimate-member/ultimate-member_reset_password.php
+++ b/friendly-captcha/modules/ultimate-member/ultimate-member_reset_password.php
@@ -36,7 +36,7 @@ function frcaptcha_um_reset_password_validate($post, $form_data)
             return;
         }
 
-        $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+        $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'ultimate-member');
 
         if (!$verification['success']) {
             $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message();

--- a/friendly-captcha/modules/woocommerce/woocommerce_checkout.php
+++ b/friendly-captcha/modules/woocommerce/woocommerce_checkout.php
@@ -40,7 +40,7 @@ function frcaptcha_wc_checkout_validate()
         return;
     }
 
-    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'woocommerce');
 
     if (!$verification['success']) {
         $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message();

--- a/friendly-captcha/modules/woocommerce/woocommerce_login.php
+++ b/friendly-captcha/modules/woocommerce/woocommerce_login.php
@@ -44,7 +44,7 @@ function frcaptcha_wc_login_validate($validation_error)
         return $validation_error;
     }
 
-    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'woocommerce');
 
     if (!$verification['success']) {
         $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message();

--- a/friendly-captcha/modules/woocommerce/woocommerce_register.php
+++ b/friendly-captcha/modules/woocommerce/woocommerce_register.php
@@ -40,7 +40,7 @@ function frcaptcha_wc_register_validate($validation_error)
         return $validation_error;
     }
 
-    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'woocommerce');
 
     if (!$verification['success']) {
         $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message();

--- a/friendly-captcha/modules/wpforms/wpforms.php
+++ b/friendly-captcha/modules/wpforms/wpforms.php
@@ -199,7 +199,7 @@ function frcaptcha_wpforms_process($fields, $entry, $form_data)
         return;
     }
 
-    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'wpforms');
 
     if (!$verification["success"]) {
         wpforms()->process->errors[$form_data['id']]['header'] = esc_html__(FriendlyCaptcha_Plugin::default_error_user_message(), 'frcaptcha');

--- a/friendly-captcha/modules/wpum/wpum_validate.php
+++ b/friendly-captcha/modules/wpum/wpum_validate.php
@@ -50,7 +50,7 @@ function frcaptcha_wpum_validate($pass, $fields, $values, $form_name, $form)
         return new WP_Error("frcaptcha-empty-error", $error_message);
     }
 
-    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
+    $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key(), 'wpum');
 
     if (!$verification['success']) {
         $error_message = $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message();

--- a/friendly-captcha/readme.txt
+++ b/friendly-captcha/readme.txt
@@ -4,7 +4,7 @@ Tags: captcha, antispam, spam, contact form, recaptcha, friendly-captcha, block 
 Requires at least: 5.0
 Tested up to: 6.5
 Requires PHP: 7.3
-Stable tag: 1.15.13
+Stable tag: 1.15.14
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -95,6 +95,10 @@ If you see an integration that's missing, please [open a pull request](https://g
 However, you may wish to email the authors of plugins you'd like to support Friendly Captcha: it will usually take them only an hour or two to add native support if they choose to do so. This will simplify your use of Friendly Captcha, and is the best solution in the long run.
 
 == Changelog ==
+
+= 1.15.14 =
+
+* Set "Frc-Sdk" header for measuring integration usage
 
 = 1.15.13 =
 


### PR DESCRIPTION
This PR adds support for passing the `Frc-Sdk` header in siteverify requests, for measuring SDK usage.