### PR TITLE
Verify captcha on WooCommerce reviews

### DIFF
--- a/friendly-captcha/modules/wordpress/wordpress_comments.php
+++ b/friendly-captcha/modules/wordpress/wordpress_comments.php
@@ -36,9 +36,8 @@ add_filter('preprocess_comment', 'frcaptcha_wp_comments_validate', 10, 1);
 
 function frcaptcha_wp_comments_validate($comment)
 {
-
     // Skip captcha for trackback or pingback
-    if ($comment['comment_type'] != '' && $comment['comment_type'] != 'comment') {
+    if ($comment['comment_type'] != '' && $comment['comment_type'] != 'comment' && $comment['comment_type'] != 'review') {
         return $comment;
     }
 


### PR DESCRIPTION
WooCommerce reviews use the WordPress comment system but have set the `comment_type` to `review`. 