### PR TITLE
Fix v2 widget rendering twice in Elementor popups

### DIFF
--- a/friendly-captcha/friendly-captcha.php
+++ b/friendly-captcha/friendly-captcha.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Friendly Captcha for WordPress
  * Description: Protect WordPress website forms from spam and abuse with Friendly Captcha, a privacy-first anti-bot solution.
- * Version: 1.15.17
+ * Version: 1.15.18
  * Requires at least: 5.0
  * Requires PHP: 7.3
  * Author: Friendly Captcha GmbH
@@ -19,7 +19,7 @@ if (!defined('WPINC')) {
 	die;
 }
 
-define('FRIENDLY_CAPTCHA_VERSION', '1.15.17');
+define('FRIENDLY_CAPTCHA_VERSION', '1.15.18');
 define('FRIENDLY_CAPTCHA_FRIENDLY_CHALLENGE_VERSION', '0.9.18');
 define('FRIENDLY_CAPTCHA_FRIENDLY_CAPTCHA_SDK_VERSION', '0.1.10');
 define('FRIENDLY_CAPTCHA_SUPPORTED_LANGUAGES', [

--- a/friendly-captcha/public/mutation-observer.js
+++ b/friendly-captcha/public/mutation-observer.js
@@ -25,7 +25,17 @@
 
   function setupV2CaptchaElements(node) {
     const elements = findCaptchaElements(node);
-    window.frcaptcha.attach(elements);
+    for (let i = 0; i < elements.length; i++) {
+      const element = elements[i];
+
+      // friendly-captcha-sdk adds the "frcWidget" property to the element when it's initialized
+      if (element && !element.frcWidget) {
+        // If the widget was initialized before and then re-inserted into the DOM, the iframe will still be there
+        // We remove any existing content to make sure we end up with exactly one iframe
+        element.innerHTML = "";
+        window.frcaptcha.attach(element);
+      }
+    }
   }
 
   const observer = new MutationObserver((mutationList) => {

--- a/friendly-captcha/readme.txt
+++ b/friendly-captcha/readme.txt
@@ -4,7 +4,7 @@ Tags: captcha, antispam, spam, contact form, recaptcha, friendly-captcha, block 
 Requires at least: 5.0
 Tested up to: 6.8
 Requires PHP: 7.3
-Stable tag: 1.15.17
+Stable tag: 1.15.18
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -95,6 +95,10 @@ If you see an integration that's missing, please [open a pull request](https://g
 However, you may wish to email the authors of plugins you'd like to support Friendly Captcha: it will usually take them only an hour or two to add native support if they choose to do so. This will simplify your use of Friendly Captcha, and is the best solution in the long run.
 
 == Changelog ==
+
+= 1.15.18 =
+
+* Fix Friendly Captcha v2 rendering twice in Elementor popups
 
 = 1.15.17 =
 


### PR DESCRIPTION
Popups in Elementor are part of the DOM when the page loads, are then copied out of the DOM when the Elementor JS has loaded, and are then inserted back when the popup actually opens.

This causes problems with our v2 widget. If our SDK has already initialized the widget in the DOM before Elementor can copy the popup, our iframe will be part of the copied popup HTML. When the popup is then opened our SDK initializes the widget again, which results in two iframes being rendered. By removing any content before initializing the Captcha we can work around that.

closes #157 