### PR TITLE
Added support for SI Schedule+Register form (StudioIntern)

### DIFF
--- a/friendly-captcha/includes/core.php
+++ b/friendly-captcha/includes/core.php
@@ -245,6 +245,13 @@ class FriendlyCaptcha_Plugin
             "plugins" => array("wp-job-openings/wp-job-openings.php", "pro-pack-for-wp-job-openings/pro-pack.php"),
             "settings_description" => "Enable Friendly Captcha for the <a href=\"https://wordpress.org/plugins/wp-job-openings/\" target=\"_blank\">WP Job Openings</a> application form.",
         ),
+        array(
+            "name" => "SI Schedule+Registration",
+            "slug" => 'tws_siwp',
+            "entry" => "tws-siwp/tws-siwp.php",
+            "plugins" => array("tws-siwp/tws-siwp.php"),
+            "settings_description" => "Enable Friendly Captcha for the SI Schedule+Registration trial lesson signup form.",
+        ),
     );
 
     public function init()

--- a/friendly-captcha/includes/core.php
+++ b/friendly-captcha/includes/core.php
@@ -250,7 +250,7 @@ class FriendlyCaptcha_Plugin
             "slug" => 'tws_siwp',
             "entry" => "tws-siwp/tws-siwp.php",
             "plugins" => array("tws-siwp/tws-siwp.php"),
-            "settings_description" => "Enable Friendly Captcha for the SI Schedule+Registration trial lesson signup form.",
+            "settings_description" => "Enable Friendly Captcha for the <a href=\"https://www.ballettschul-software.de/zusatzmodule.php#sischedreg\" target=\"_blank\">SI Schedule+Registration</a> trial lesson signup form.",
         ),
     );
 
@@ -401,6 +401,6 @@ require plugin_dir_path(__FILE__) . 'settings.php';
 
 foreach (FriendlyCaptcha_Plugin::$integrations as $integration) {
     if (FriendlyCaptcha_Plugin::$instance->get_integration_active($integration['slug'])) {
-        require_once plugin_dir_path(__FILE__) . '../modules/' . $integration['entry'];
+        include_once plugin_dir_path(__FILE__) . '../modules/' . $integration['entry'];
     }
 }

--- a/friendly-captcha/modules/tws-siwp/index.php
+++ b/friendly-captcha/modules/tws-siwp/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/friendly-captcha/modules/tws-siwp/tws-siwp.php
+++ b/friendly-captcha/modules/tws-siwp/tws-siwp.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * FriendlyCaptcha integration for SI Schedule+Registration (tws-siwp) plugin.
+ * 
+ * Hooks into the tws-siwp form display and validation filters.
+ */
+
+// Add captcha widget to registration form
+add_filter(
+    'tws_siwp_captcha_widget', function ($html) {
+        $plugin = FriendlyCaptcha_Plugin::$instance;
+        if (!$plugin->is_configured()) {
+            return $html;
+        }
+
+        frcaptcha_enqueue_widget_scripts();
+
+        $widget = frcaptcha_generate_widget_tag_from_plugin($plugin);
+        return $html . $widget;
+    }
+);
+
+// Validate captcha on form submission
+// $form_data is passed for potential future use (e.g. logging)
+add_filter(
+    'tws_siwp_validate_captcha', function ($error, $form_data) {
+        unset($form_data); // Currently unused, but available for future extensions
+        $plugin = FriendlyCaptcha_Plugin::$instance;
+        if (!$plugin->is_configured()) {
+            return $error;
+        }
+
+        $solution = frcaptcha_get_sanitized_frcaptcha_solution_from_post();
+
+        if (empty($solution)) {
+            /* translators: Error message when captcha was not completed */
+            return __("Bitte lösen Sie das Anti-Spam-Rätsel.", "frcaptcha");
+        }
+
+        $verification = frcaptcha_verify_captcha_solution(
+            $solution, 
+            $plugin->get_sitekey(), 
+            $plugin->get_api_key(), 
+            'tws-siwp'
+        );
+
+        if (!$verification["success"]) {
+            return FriendlyCaptcha_Plugin::default_error_user_message();
+        }
+
+        return $error;
+    }, 10, 2
+);


### PR DESCRIPTION
## What is SI Schedule+Register? ##
SI Schedule+Register is a Wordpress PlugIn which can fetch dance class schedules from a StudioIntern SaaS instance and display it inside a Wordpress page. Further, it can display a registration form / trial lesson appointment form which then will be sent to the StudioIntern instance.
## What is the change intended for? ##
The changes I made is simply adding a module to support the StudioIntern SI Schedule+Register form.
## Where can I get more information on StudioIntern and this special form? ##
For information on StudioIntern in general, visit https://www.ballettschul-software.de/ .
For information about the SI Schedule+Register WP Plugin, see https://www.ballettschul-software.de/zusatzmodule.php#sischedreg
Send support requests to support@studiointern.de .