### PR TITLE
Added support for generic implementation (very simple)

### DIFF
--- a/friendly-captcha/includes/core.php
+++ b/friendly-captcha/includes/core.php
@@ -245,6 +245,13 @@ class FriendlyCaptcha_Plugin
             "plugins" => array("wp-job-openings/wp-job-openings.php", "pro-pack-for-wp-job-openings/pro-pack.php"),
             "settings_description" => "Enable Friendly Captcha for the <a href=\"https://wordpress.org/plugins/wp-job-openings/\" target=\"_blank\">WP Job Openings</a> application form.",
         ),
+        array(
+            "name" => "Generic Integration (for custom and unsupported plugins)",
+            "slug" => "generic_integration",
+            "entry" => "generic_integration/generic_integration.php",
+            "plugins" => [],
+            "settings_description" => "Enable Friendly Captcha for integrations with user-defined PHP-Code. (not recommended)",
+        ),
     );
 
     public function init()

--- a/friendly-captcha/includes/core.php
+++ b/friendly-captcha/includes/core.php
@@ -3,7 +3,6 @@
 /* Main entry point */
 class FriendlyCaptcha_Plugin
 {
-
     /**
      * Singleton global instance
      * @var FriendlyCaptcha_Plugin
@@ -33,239 +32,278 @@ class FriendlyCaptcha_Plugin
 
     public static $option_verification_failed_alert_name = "frcaptcha_verification_failed_alert_v2";
 
-    public static $integrations = array(
-        array(
+    public static $integrations = [
+        [
             "name" => "Contact Form 7",
-            "slug" => 'contact_form_7',
+            "slug" => "contact_form_7",
             "entry" => "contact-form-7/contact-form-7.php",
-            "plugins" => array("contact-form-7/wp-contact-form-7.php"),
-            "settings_description" => "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/contact-form-7/\" target=\"_blank\">Contact Form 7</a> forms.",
-        ),
-        array(
+            "plugins" => ["contact-form-7/wp-contact-form-7.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/contact-form-7/\" target=\"_blank\">Contact Form 7</a> forms.",
+        ],
+        [
             "name" => "CF7 Double-Opt-In",
-            "slug" => 'f12_cf7_doubleoptin',
+            "slug" => "f12_cf7_doubleoptin",
             "entry" => "contact-form-7/contact-form-7.php",
-            "plugins" => array("contact-form-7/wp-contact-form-7.php"),
-            "settings_description" => "Enable support for the Forge12 Double Opt-In plugin for Contact Form 7. You need to enable Contact Form 7 as well.",
-        ),
-        array(
+            "plugins" => ["contact-form-7/wp-contact-form-7.php"],
+            "settings_description" =>
+                "Enable support for the Forge12 Double Opt-In plugin for Contact Form 7. You need to enable Contact Form 7 as well.",
+        ],
+        [
             "name" => "WPForms",
-            "slug" => 'wpforms',
+            "slug" => "wpforms",
             "entry" => "wpforms/wpforms.php",
-            "plugins" => array("wpforms/wpforms.php", "wpforms-lite/wpforms.php"),
-            "settings_description" => "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/wpforms/\" target=\"_blank\">WPForms</a> and <a href=\"https://wordpress.org/plugins/wpforms-lite/\"  target=\"_blank\">WPForms lite</a> forms.",
-        ),
-        array(
+            "plugins" => ["wpforms/wpforms.php", "wpforms-lite/wpforms.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/wpforms/\" target=\"_blank\">WPForms</a> and <a href=\"https://wordpress.org/plugins/wpforms-lite/\"  target=\"_blank\">WPForms lite</a> forms.",
+        ],
+        [
             "name" => "Gravity Forms",
-            "slug" => 'gravity_forms',
+            "slug" => "gravity_forms",
             "entry" => "gravityforms/gravityforms.php",
-            "plugins" => array("gravityforms/gravityforms.php"),
-            "settings_description" => "Enable Friendly Captcha for <a href=\"https://gravityforms.com\" target=\"_blank\">Gravity Forms</a> forms.<br> The widget is available under <i>Advanced Fields</i> in the form builder. For the best protection add the widget to the last page in multi-page forms.",
-        ),
-        array(
+            "plugins" => ["gravityforms/gravityforms.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for <a href=\"https://gravityforms.com\" target=\"_blank\">Gravity Forms</a> forms.<br> The widget is available under <i>Advanced Fields</i> in the form builder. For the best protection add the widget to the last page in multi-page forms.",
+        ],
+        [
             "name" => "CoBlocks Forms",
-            "slug" => 'coblocks',
+            "slug" => "coblocks",
             "entry" => "coblocks/coblocks.php",
-            "plugins" => array("coblocks/class-coblocks.php"),
-            "settings_description" => "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/coblocks/\" target=\"_blank\">CoBlocks</a> forms.",
-        ),
-        array(
+            "plugins" => ["coblocks/class-coblocks.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/coblocks/\" target=\"_blank\">CoBlocks</a> forms.",
+        ],
+        [
             "name" => "Fluent Forms",
-            "slug" => 'fluentform',
+            "slug" => "fluentform",
             "entry" => "fluentform/fluentform.php",
-            "plugins" => array("fluentform/fluentform.php"),
-            "settings_description" => "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/fluentform/\" target=\"_blank\">Fluentform</a> forms.",
-        ),
-        array(
+            "plugins" => ["fluentform/fluentform.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/fluentform/\" target=\"_blank\">Fluentform</a> forms.",
+        ],
+        [
             "name" => "Elementor Pro Forms",
-            "slug" => 'elementor',
+            "slug" => "elementor",
             "entry" => "elementor/elementor.php",
-            "plugins" => array("elementor/elementor.php", "elementor-pro/elementor-pro.php"),
-            "settings_description" => "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/elementor/\" target=\"_blank\">Elementor Pro</a> forms.<br> The widget is available as a field type in Elementor Pro form editor. Add it as a field to the forms that you want to protect.",
-        ),
-        array(
+            "plugins" => [
+                "elementor/elementor.php",
+                "elementor-pro/elementor-pro.php",
+            ],
+            "settings_description" =>
+                "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/elementor/\" target=\"_blank\">Elementor Pro</a> forms.<br> The widget is available as a field type in Elementor Pro form editor. Add it as a field to the forms that you want to protect.",
+        ],
+        [
             "name" => "HTML Forms",
-            "slug" => 'html_forms',
+            "slug" => "html_forms",
             "entry" => "html-forms/html-forms.php",
-            "plugins" => array("html-forms/html-forms.php"),
-            "settings_description" => "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/html-forms/\" target=\"_blank\">HTML Forms</a>.",
-        ),
-        array(
+            "plugins" => ["html-forms/html-forms.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/html-forms/\" target=\"_blank\">HTML Forms</a>.",
+        ],
+        [
             "name" => "Forminator",
-            "slug" => 'forminator',
+            "slug" => "forminator",
             "entry" => "forminator/forminator.php",
-            "plugins" => array("forminator/forminator.php"),
-            "settings_description" => "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/forminator/\" target=\"_blank\">Forminator</a>.",
-        ),
-        array(
+            "plugins" => ["forminator/forminator.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/forminator/\" target=\"_blank\">Forminator</a>.",
+        ],
+        [
             "name" => "Formidable",
-            "slug" => 'formidable',
+            "slug" => "formidable",
             "entry" => "formidable/formidable.php",
-            "plugins" => array("formidable/formidable.php"),
-            "settings_description" => "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/formidable/\" target=\"_blank\">Formidable</a>.<br /><strong>Important:</strong> Make sure to add the new Friendly Captcha field to your forms.",
-        ),
-        array(
+            "plugins" => ["formidable/formidable.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for <a href=\"https://wordpress.org/plugins/formidable/\" target=\"_blank\">Formidable</a>.<br /><strong>Important:</strong> Make sure to add the new Friendly Captcha field to your forms.",
+        ],
+        [
             "name" => "Avada Forms",
-            "slug" => 'avada_forms',
+            "slug" => "avada_forms",
             "entry" => "avada-forms/avada-forms.php",
-            "plugins" => array("avada-forms/avada-forms.php"),
-            "settings_description" => "Enable Friendly Captcha for Avada Form Builder.",
-        ),
-        array(
+            "plugins" => ["avada-forms/avada-forms.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for Avada Form Builder.",
+        ],
+        [
             "name" => "WordPress Register",
-            "slug" => 'wp_register',
+            "slug" => "wp_register",
             "entry" => "wordpress/wordpress_register.php",
-            "settings_description" => "Enable Friendly Captcha for the WordPress sign up form.",
-        ),
-        array(
+            "settings_description" =>
+                "Enable Friendly Captcha for the WordPress sign up form.",
+        ],
+        [
             "name" => "WordPress Login",
-            "slug" => 'wp_login',
+            "slug" => "wp_login",
             "entry" => "wordpress/wordpress_login.php",
-            "settings_description" => "Enable Friendly Captcha for the WordPress log in form.",
-        ),
-        array(
+            "settings_description" =>
+                "Enable Friendly Captcha for the WordPress log in form.",
+        ],
+        [
             "name" => "WordPress Reset Password",
-            "slug" => 'wp_reset_password',
+            "slug" => "wp_reset_password",
             "entry" => "wordpress/wordpress_reset_password.php",
-            "settings_description" => "Enable Friendly Captcha for the WordPress <i>\"Reset Password\"</i> form.",
-        ),
-        array(
+            "settings_description" =>
+                "Enable Friendly Captcha for the WordPress <i>\"Reset Password\"</i> form.",
+        ],
+        [
             "name" => "WordPress Comments<br>(guests)",
-            "slug" => 'wp_comments',
+            "slug" => "wp_comments",
             "entry" => "wordpress/wordpress_comments.php",
-            "settings_description" => "Enable Friendly Captcha for WordPress Comments for guest visitors.",
-        ),
-        array(
+            "settings_description" =>
+                "Enable Friendly Captcha for WordPress Comments for guest visitors.",
+        ],
+        [
             "name" => "WordPress Comments<br>(logged in users)",
-            "slug" => 'wp_comments_logged_in',
+            "slug" => "wp_comments_logged_in",
             "entry" => "wordpress/wordpress_comments.php",
-            "settings_description" => "Enable Friendly Captcha for WordPress Comments for users that are logged in to Wordpress.",
-        ),
-        array(
+            "settings_description" =>
+                "Enable Friendly Captcha for WordPress Comments for users that are logged in to Wordpress.",
+        ],
+        [
             "name" => "WooCommerce Login",
-            "slug" => 'wc_login',
+            "slug" => "wc_login",
             "entry" => "woocommerce/woocommerce_login.php",
-            "plugins" => array("woocommerce/woocommerce.php"),
-            "settings_description" => "Enable Friendly Captcha for the WooCommerce log in form.",
-        ),
-        array(
+            "plugins" => ["woocommerce/woocommerce.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for the WooCommerce log in form.",
+        ],
+        [
             "name" => "WooCommerce Register",
-            "slug" => 'wc_register',
+            "slug" => "wc_register",
             "entry" => "woocommerce/woocommerce_register.php",
-            "plugins" => array("woocommerce/woocommerce.php"),
-            "settings_description" => "Enable Friendly Captcha for the WooCommerce sign up form.",
-        ),
-        array(
+            "plugins" => ["woocommerce/woocommerce.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for the WooCommerce sign up form.",
+        ],
+        [
             "name" => "WooCommerce Lost Password",
-            "slug" => 'wc_lost_password',
+            "slug" => "wc_lost_password",
             "entry" => "woocommerce/woocommerce_lost_password.php",
-            "plugins" => array("woocommerce/woocommerce.php"),
-            "settings_description" => "Enable Friendly Captcha for the WooCommerce lost password form.",
-        ),
-        array(
+            "plugins" => ["woocommerce/woocommerce.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for the WooCommerce lost password form.",
+        ],
+        [
             "name" => "WooCommerce Checkout",
-            "slug" => 'wc_checkout',
+            "slug" => "wc_checkout",
             "entry" => "woocommerce/woocommerce_checkout.php",
-            "plugins" => array("woocommerce/woocommerce.php"),
-            "settings_description" => "Enable Friendly Captcha for the WooCommerce checkout form.",
-        ),
-        array(
+            "plugins" => ["woocommerce/woocommerce.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for the WooCommerce checkout form.",
+        ],
+        [
             "name" => "Ultimate Member Login",
-            "slug" => 'um_login',
+            "slug" => "um_login",
             "entry" => "ultimate-member/ultimate-member_login.php",
-            "plugins" => array("ultimate-member/ultimate-member.php"),
-            "settings_description" => "Enable Friendly Captcha for the Ultimate Member login form.",
-        ),
-        array(
+            "plugins" => ["ultimate-member/ultimate-member.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for the Ultimate Member login form.",
+        ],
+        [
             "name" => "Ultimate Member Register",
-            "slug" => 'um_register',
+            "slug" => "um_register",
             "entry" => "ultimate-member/ultimate-member_register.php",
-            "plugins" => array("ultimate-member/ultimate-member.php"),
-            "settings_description" => "Enable Friendly Captcha for the Ultimate Member sign up form.",
-        ),
-        array(
+            "plugins" => ["ultimate-member/ultimate-member.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for the Ultimate Member sign up form.",
+        ],
+        [
             "name" => "Ultimate Member Reset Password",
-            "slug" => 'um_reset_password',
+            "slug" => "um_reset_password",
             "entry" => "ultimate-member/ultimate-member_reset_password.php",
-            "plugins" => array("ultimate-member/ultimate-member.php"),
-            "settings_description" => "Enable Friendly Captcha for the Ultimate Member reset password form.",
-        ),
-        array(
+            "plugins" => ["ultimate-member/ultimate-member.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for the Ultimate Member reset password form.",
+        ],
+        [
             "name" => "WPUM Login",
-            "slug" => 'wpum_login',
+            "slug" => "wpum_login",
             "entry" => "wpum/wpum_login.php",
-            "plugins" => array("wp-user-manager/wp-user-manager.php"),
-            "settings_description" => "Enable Friendly Captcha for the WP User Manager login form.",
-        ),
-        array(
+            "plugins" => ["wp-user-manager/wp-user-manager.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for the WP User Manager login form.",
+        ],
+        [
             "name" => "WPUM Registration",
-            "slug" => 'wpum_registration',
+            "slug" => "wpum_registration",
             "entry" => "wpum/wpum_registration.php",
-            "plugins" => array("wp-user-manager/wp-user-manager.php"),
-            "settings_description" => "Enable Friendly Captcha for the WP User Manager registration form.",
-        ),
-        array(
+            "plugins" => ["wp-user-manager/wp-user-manager.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for the WP User Manager registration form.",
+        ],
+        [
             "name" => "WPUM Password Recovery",
-            "slug" => 'wpum_password_recovery',
+            "slug" => "wpum_password_recovery",
             "entry" => "wpum/wpum_password-recovery.php",
-            "plugins" => array("wp-user-manager/wp-user-manager.php"),
-            "settings_description" => "Enable Friendly Captcha for the WP User Manager password recovery form.",
-        ),
-        array(
+            "plugins" => ["wp-user-manager/wp-user-manager.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for the WP User Manager password recovery form.",
+        ],
+        [
             "name" => "Profile Builder Login",
-            "slug" => 'pb_login',
+            "slug" => "pb_login",
             "entry" => "profile-builder/profile_builder_login.php",
-            "plugins" => array("profile-builder/index.php"),
-            "settings_description" => "Enable Friendly Captcha for the <a href=\"https://de.wordpress.org/plugins/profile-builder/\" target=\"_blank\">Profile Builder</a> login form.",
-        ),
-        array(
+            "plugins" => ["profile-builder/index.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for the <a href=\"https://de.wordpress.org/plugins/profile-builder/\" target=\"_blank\">Profile Builder</a> login form.",
+        ],
+        [
             "name" => "Profile Builder Register",
-            "slug" => 'pb_register',
+            "slug" => "pb_register",
             "entry" => "profile-builder/profile_builder_register.php",
-            "plugins" => array("profile-builder/index.php"),
-            "settings_description" => "Enable Friendly Captcha for the <a href=\"https://de.wordpress.org/plugins/profile-builder/\" target=\"_blank\">Profile Builder</a> sign up form.",
-        ),
-        array(
+            "plugins" => ["profile-builder/index.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for the <a href=\"https://de.wordpress.org/plugins/profile-builder/\" target=\"_blank\">Profile Builder</a> sign up form.",
+        ],
+        [
             "name" => "Profile Builder Reset Password",
-            "slug" => 'pb_reset_password',
+            "slug" => "pb_reset_password",
             "entry" => "profile-builder/profile_builder_reset_password.php",
-            "plugins" => array("profile-builder/index.php"),
-            "settings_description" => "Enable Friendly Captcha for the <a href=\"https://de.wordpress.org/plugins/profile-builder/\" target=\"_blank\">Profile Builder</a> reset password form.",
-        ),
-        array(
+            "plugins" => ["profile-builder/index.php"],
+            "settings_description" =>
+                "Enable Friendly Captcha for the <a href=\"https://de.wordpress.org/plugins/profile-builder/\" target=\"_blank\">Profile Builder</a> reset password form.",
+        ],
+        [
             "name" => "Divi Theme Contact Form",
-            "slug" => 'divi',
+            "slug" => "divi",
             "entry" => "divi/divi.php",
-            "settings_description" => "Enable Friendly Captcha and replace ReCaptcha in the <a href=\"https://www.elegantthemes.com/gallery/divi//\" target=\"_blank\">Divi Theme</a> contact form.<br /><strong>Important:</strong> Please choose 'FriendlyCaptcha verification' as spam protection in each individual Divi contact form.",
-        ),
-        array(
+            "settings_description" =>
+                "Enable Friendly Captcha and replace ReCaptcha in the <a href=\"https://www.elegantthemes.com/gallery/divi//\" target=\"_blank\">Divi Theme</a> contact form.<br /><strong>Important:</strong> Please choose 'FriendlyCaptcha verification' as spam protection in each individual Divi contact form.",
+        ],
+        [
             "name" => "WP Job Openings",
-            "slug" => 'wp_job_openings',
+            "slug" => "wp_job_openings",
             "entry" => "wp-job-openings/wp-job-openings.php",
-            "plugins" => array("wp-job-openings/wp-job-openings.php", "pro-pack-for-wp-job-openings/pro-pack.php"),
-            "settings_description" => "Enable Friendly Captcha for the <a href=\"https://wordpress.org/plugins/wp-job-openings/\" target=\"_blank\">WP Job Openings</a> application form.",
-        ),
-        array(
-            "name" => "Generic Integration (for custom and unsupported plugins)",
-            "slug" => 'fc_generic_integration',
-            "entry" => "fc_generic_integration/fc_generic_integration.php",
-            "plugins" => array(),
-            "settings_description" => "Enable Friendly Captcha for integrations with user-defined PHP-Code. (not recommended)",
-        ),
-    );
+            "plugins" => [
+                "wp-job-openings/wp-job-openings.php",
+                "pro-pack-for-wp-job-openings/pro-pack.php",
+            ],
+            "settings_description" =>
+                "Enable Friendly Captcha for the <a href=\"https://wordpress.org/plugins/wp-job-openings/\" target=\"_blank\">WP Job Openings</a> application form.",
+        ],
+        [
+            "name" =>
+                "Generic Integration (for custom and unsupported plugins)",
+            "slug" => "generic_integration",
+            "entry" => "generic_integration/generic_integration.php",
+            "plugins" => [],
+            "settings_description" =>
+                "Enable Friendly Captcha for integrations with user-defined PHP-Code. (not recommended)",
+        ],
+    ];
 
     public function init()
     {
-        if (defined('FRIENDLY_CAPTCHA_VERSION')) {
+        if (defined("FRIENDLY_CAPTCHA_VERSION")) {
             FriendlyCaptcha_Plugin::$version = FRIENDLY_CAPTCHA_VERSION;
             FriendlyCaptcha_Plugin::$friendly_challenge_version = FRIENDLY_CAPTCHA_FRIENDLY_CHALLENGE_VERSION;
             FriendlyCaptcha_Plugin::$friendly_captcha_sdk_version = FRIENDLY_CAPTCHA_FRIENDLY_CAPTCHA_SDK_VERSION;
         } else {
-            FriendlyCaptcha_Plugin::$version = '0.0.0';
-            FriendlyCaptcha_Plugin::$friendly_challenge_version = '0.0.0';
-            FriendlyCaptcha_Plugin::$friendly_captcha_sdk_version = '0.0.0';
+            FriendlyCaptcha_Plugin::$version = "0.0.0";
+            FriendlyCaptcha_Plugin::$friendly_challenge_version = "0.0.0";
+            FriendlyCaptcha_Plugin::$friendly_captcha_sdk_version = "0.0.0";
         }
-        $this->plugin_name = 'friendly-captcha';
+        $this->plugin_name = "friendly-captcha";
 
         FriendlyCaptcha_Plugin::$instance = $this;
     }
@@ -273,7 +311,10 @@ class FriendlyCaptcha_Plugin
     public static function default_error_user_message()
     {
         /* translators: this is the main error message shown to the user when the captcha failed or wasn't completed. */
-        return __("Anti-robot verification failed, please try again.", "frcaptcha");
+        return __(
+            "Anti-robot verification failed, please try again.",
+            "frcaptcha",
+        );
     }
 
     /**
@@ -281,7 +322,10 @@ class FriendlyCaptcha_Plugin
      */
     public function is_configured()
     {
-        return $this->get_sitekey() !== null && $this->get_sitekey() !== "" && $this->get_api_key() !== null && $this->get_api_key() !== "";
+        return $this->get_sitekey() !== null &&
+            $this->get_sitekey() !== "" &&
+            $this->get_api_key() !== null &&
+            $this->get_api_key() !== "";
     }
 
     public function get_sitekey()
@@ -296,12 +340,16 @@ class FriendlyCaptcha_Plugin
 
     public function get_skip_style_injection()
     {
-        return get_option(FriendlyCaptcha_Plugin::$option_skip_style_injection_name) == 1;
+        return get_option(
+            FriendlyCaptcha_Plugin::$option_skip_style_injection_name,
+        ) == 1;
     }
 
     public function get_enable_mutation_observer()
     {
-        return get_option(FriendlyCaptcha_Plugin::$option_enable_mutation_observer_name) == 1;
+        return get_option(
+            FriendlyCaptcha_Plugin::$option_enable_mutation_observer_name,
+        ) == 1;
     }
 
     public function get_enable_v2()
@@ -333,11 +381,15 @@ class FriendlyCaptcha_Plugin
 
     public function get_widget_language()
     {
-        $lang = get_option(FriendlyCaptcha_Plugin::$option_widget_language_name);
+        $lang = get_option(
+            FriendlyCaptcha_Plugin::$option_widget_language_name,
+        );
         $lang = empty($lang) ? "automatic" : $lang; // Default to automatic
         if ($lang == "automatic") {
             $lang = substr(get_locale(), 0, 2);
-            if (!array_key_exists($lang, FRIENDLY_CAPTCHA_SUPPORTED_LANGUAGES)) {
+            if (
+                !array_key_exists($lang, FRIENDLY_CAPTCHA_SUPPORTED_LANGUAGES)
+            ) {
                 $lang = "en"; // Fallback to en
             }
         }
@@ -346,39 +398,54 @@ class FriendlyCaptcha_Plugin
 
     public function get_widget_dark_theme_active()
     {
-        return get_option(FriendlyCaptcha_Plugin::$option_widget_dark_theme_active_name) == 1;
+        return get_option(
+            FriendlyCaptcha_Plugin::$option_widget_dark_theme_active_name,
+        ) == 1;
     }
 
     /* Endpoint settings */
 
     public function get_eu_puzzle_endpoint_active()
     {
-        return get_option(FriendlyCaptcha_Plugin::$option_eu_puzzle_endpoint_active_name) == 1;
+        return get_option(
+            FriendlyCaptcha_Plugin::$option_eu_puzzle_endpoint_active_name,
+        ) == 1;
     }
 
     public function get_global_puzzle_endpoint_active()
     {
         $eu_active = $this->get_eu_puzzle_endpoint_active();
-        if (!$eu_active) return true; // At least one must be enabled.
+        if (!$eu_active) {
+            return true;
+        } // At least one must be enabled.
 
-        return get_option(FriendlyCaptcha_Plugin::$option_global_puzzle_endpoint_active_name) == 1;
+        return get_option(
+            FriendlyCaptcha_Plugin::$option_global_puzzle_endpoint_active_name,
+        ) == 1;
     }
 
     /* Verification failure alert */
 
     public function show_verification_failed_alert($response)
     {
-        update_option(FriendlyCaptcha_Plugin::$option_verification_failed_alert_name, $response);
+        update_option(
+            FriendlyCaptcha_Plugin::$option_verification_failed_alert_name,
+            $response,
+        );
     }
 
     public function get_verification_failed_alert()
     {
-        return get_option(FriendlyCaptcha_Plugin::$option_verification_failed_alert_name);
+        return get_option(
+            FriendlyCaptcha_Plugin::$option_verification_failed_alert_name,
+        );
     }
 
     public function remove_verification_failed_alert()
     {
-        delete_option(FriendlyCaptcha_Plugin::$option_verification_failed_alert_name);
+        delete_option(
+            FriendlyCaptcha_Plugin::$option_verification_failed_alert_name,
+        );
     }
 }
 
@@ -389,18 +456,24 @@ if (!isset(FriendlyCaptcha_Plugin::$instance)) {
 }
 
 // These only contain pure functions
-require plugin_dir_path(__FILE__) . 'helpers.php';
-require plugin_dir_path(__FILE__) . 'verification.php';
+require plugin_dir_path(__FILE__) . "helpers.php";
+require plugin_dir_path(__FILE__) . "verification.php";
 
 // Register widget routines
-require plugin_dir_path(__FILE__) . '../public/widgets.php';
+require plugin_dir_path(__FILE__) . "../public/widgets.php";
 
 // Set up the admin pages & settings
-require plugin_dir_path(__FILE__) . 'admin.php';
-require plugin_dir_path(__FILE__) . 'settings.php';
+require plugin_dir_path(__FILE__) . "admin.php";
+require plugin_dir_path(__FILE__) . "settings.php";
 
 foreach (FriendlyCaptcha_Plugin::$integrations as $integration) {
-    if (FriendlyCaptcha_Plugin::$instance->get_integration_active($integration['slug'])) {
-        require_once plugin_dir_path(__FILE__) . '../modules/' . $integration['entry'];
+    if (
+        FriendlyCaptcha_Plugin::$instance->get_integration_active(
+            $integration["slug"],
+        )
+    ) {
+        require_once plugin_dir_path(__FILE__) .
+            "../modules/" .
+            $integration["entry"];
     }
 }

--- a/friendly-captcha/includes/core.php
+++ b/friendly-captcha/includes/core.php
@@ -245,6 +245,13 @@ class FriendlyCaptcha_Plugin
             "plugins" => array("wp-job-openings/wp-job-openings.php", "pro-pack-for-wp-job-openings/pro-pack.php"),
             "settings_description" => "Enable Friendly Captcha for the <a href=\"https://wordpress.org/plugins/wp-job-openings/\" target=\"_blank\">WP Job Openings</a> application form.",
         ),
+        array(
+            "name" => "Generic Integration (for custom and unsupported plugins)",
+            "slug" => 'fc_generic_integration',
+            "entry" => "fc_generic_integration/fc_generic_integration.php",
+            "plugins" => array(),
+            "settings_description" => "Enable Friendly Captcha for integrations with user-defined PHP-Code. (not recommended)",
+        ),
     );
 
     public function init()

--- a/friendly-captcha/modules/generic_integration/generic_integration.php
+++ b/friendly-captcha/modules/generic_integration/generic_integration.php
@@ -21,7 +21,7 @@ add_filter("fch_captcha_append_widget", function ($html) {
 
 /** Validate captcha on form submission
  * @param  string $solution value of $_POST['frc-captcha-solution']
- * @param  bool $lax_on_failure how to decide on network failure: returning false here means a broken network failure is treated as a bot.
+ * @param  bool $lax_on_failure how to decide on network failure: returning false here means a broken network failure or integration in settings is deactivated is treated as a bot.
  * @return bool           true = human, false = bot / missing solution
  */
 add_filter(
@@ -29,12 +29,12 @@ add_filter(
     function ($solution, $lax_on_failure) {
         $plugin = FriendlyCaptcha_Plugin::$instance;
 
-        if (empty($solution)) {
-            return false;
-        }
-
         if (!$plugin->is_configured()) {
             return $lax_on_failure;
+        }
+
+        if (empty($solution)) {
+            return false;
         }
 
         $verification = frcaptcha_verify_captcha_solution(

--- a/friendly-captcha/modules/generic_integration/generic_integration.php
+++ b/friendly-captcha/modules/generic_integration/generic_integration.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * FriendlyCaptcha Helper to integrate better with custom code.
+ */
+
+/** Add captcha to forms
+ * @param  string $html  html to append the captcha widget to
+ * @return string        html with captcha widget appended
+ */
+add_filter("fch_captcha_append_widget", function ($html) {
+    $plugin = FriendlyCaptcha_Plugin::$instance;
+    if (!$plugin->is_configured()) {
+        return $html;
+    }
+
+    frcaptcha_enqueue_widget_scripts();
+
+    $widget = frcaptcha_generate_widget_tag_from_plugin($plugin);
+    return $html . $widget;
+});
+
+/** Validate captcha on form submission
+ * @param  string $solution value of $_POST['frc-captcha-solution']
+ * @param  bool $lax_on_failure how to decide on network failure: returning false here means a broken network failure or integration in settings is deactivated is treated as a bot.
+ * @return bool           true = human, false = bot / missing solution
+ */
+add_filter(
+    "fch_captcha_validation",
+    function ($solution, $lax_on_failure) {
+        $plugin = FriendlyCaptcha_Plugin::$instance;
+
+        if (!$plugin->is_configured()) {
+            return $lax_on_failure;
+        }
+
+        if (empty($solution)) {
+            return false;
+        }
+
+        $verification = frcaptcha_verify_captcha_solution(
+            $solution,
+            $plugin->get_sitekey(),
+            $plugin->get_api_key(),
+            "generic_integration",
+        );
+
+        return $verification["success"];
+    },
+    10,
+    2,
+);

--- a/friendly-captcha/modules/generic_integration/generic_integration.php
+++ b/friendly-captcha/modules/generic_integration/generic_integration.php
@@ -25,7 +25,7 @@ add_filter("fch_captcha_append_widget", function ($html) {
  * @return bool           true = human, false = bot / missing solution
  */
 add_filter(
-    "fch_captcha_validation",
+    "frc_captcha_validation",
     function ($solution, $lax_on_failure) {
         $plugin = FriendlyCaptcha_Plugin::$instance;
 

--- a/friendly-captcha/modules/generic_integration/generic_integration.php
+++ b/friendly-captcha/modules/generic_integration/generic_integration.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * FriendlyCaptcha Helper to integrate better with custom code.
+ */
+
+/** Add captcha to forms
+ * @param  string $html  html to append the captcha widget to
+ * @return string        html with captcha widget appended
+ */
+add_filter("fch_captcha_append_widget", function ($html) {
+    $plugin = FriendlyCaptcha_Plugin::$instance;
+    if (!$plugin->is_configured()) {
+        return $html;
+    }
+
+    frcaptcha_enqueue_widget_scripts();
+
+    $widget = frcaptcha_generate_widget_tag_from_plugin($plugin);
+    return $html . $widget;
+});
+
+/** Validate captcha on form submission
+ * @param  string $solution value of $_POST['frc-captcha-solution']
+ * @param  bool $lax_on_failure how to decide on network failure: returning false here means a broken network failure is treated as a bot.
+ * @return bool           true = human, false = bot / missing solution
+ */
+add_filter(
+    "fch_captcha_validation",
+    function ($solution, $lax_on_failure) {
+        $plugin = FriendlyCaptcha_Plugin::$instance;
+
+        if (empty($solution)) {
+            return false;
+        }
+
+        if (!$plugin->is_configured()) {
+            return $lax_on_failure;
+        }
+
+        $verification = frcaptcha_verify_captcha_solution(
+            $solution,
+            $plugin->get_sitekey(),
+            $plugin->get_api_key(),
+            "generic_integration",
+        );
+
+        return $verification["success"];
+    },
+    10,
+    2,
+);

--- a/friendly-captcha/modules/generic_integration/generic_integration.php
+++ b/friendly-captcha/modules/generic_integration/generic_integration.php
@@ -7,7 +7,7 @@
  * @param  string $html  html to append the captcha widget to
  * @return string        html with captcha widget appended
  */
-add_filter("fch_captcha_append_widget", function ($html) {
+add_filter("frc_captcha_append_widget", function ($html) {
     $plugin = FriendlyCaptcha_Plugin::$instance;
     if (!$plugin->is_configured()) {
         return $html;


### PR DESCRIPTION
Hey,

i was looking for documentation to integrate FriendlyCaptcha into a custom plugin and found basically nothing.

My unknown friend Steve was looking for [something like this](https://github.com/FriendlyCaptcha/friendly-captcha-wordpress/issues/113) as well. 

I grabbed most of the code from [#167](https://github.com/FriendlyCaptcha/friendly-captcha-wordpress/pull/167) for simplicity. Thanks to @RealZendor for the great base.

Implementation would be made in two simple steps after enabling the option in the settings.  

Use the filter 'fch_captcha_append_widget' on your form or an empty string and print it:
```php
$html = apply_filters( 'fch_captcha_append_widget', '' );
echo $html;
```

Use the filter 'fch_captcha_validation' before handling your inputs and get a bool (true = human, false = bot / missing solution):
```php
$solution = sanitize_text_field($_POST["frc-captcha-solution"]);
$verified = apply_filters( 'fch_captcha_validation', $solution, true );
```

Let me know if you are looking to merge this or not.

Thanks for the great software btw!