### PR TITLE
Only show verification error alert for configuration issues

### DIFF
--- a/friendly-captcha/includes/admin.php
+++ b/friendly-captcha/includes/admin.php
@@ -65,6 +65,11 @@ if (is_admin()) {
     if (FriendlyCaptcha_Plugin::$instance->get_verification_failed_alert() != false) {
         function frcaptcha_admin_notice__verification_failed()
         {
+            $alert = FriendlyCaptcha_Plugin::$instance->get_verification_failed_alert();
+            if ($alert == false) {
+                return;
+            }
+
             $settings_url = esc_url(add_query_arg(
                 'page',
                 'friendly_captcha_admin',
@@ -78,9 +83,13 @@ if (is_admin()) {
                 <p>
                     <b>Friendly Captcha verification has failed!</b>
                     <br>
-                    This is usually because you have entered an incorrect API Key. Please visit the <a href="<?php echo $settings_url ?>">Friendly Captcha settings</a> and enter a valid Sitekey and API Key.
+                    This is usually because you have entered an incorrect API Key. If you aren't sure, visit the <a href="<?php echo $settings_url ?>">Friendly Captcha settings</a> and enter a valid Sitekey and API Key.
+                    <?php if (!empty($alert['time'])) : ?>
+                        <br><br>
+                        Last failure: <b><?php echo esc_html(wp_date(get_option('date_format') . ' ' . get_option('time_format'), $alert['time'])); ?></b>. This notice clears automatically a week after the last failure.
+                    <?php endif; ?>
                     <br><br>
-                    <code><?php echo FriendlyCaptcha_Plugin::$instance->get_verification_failed_alert(); ?></code>
+                    <code><?php echo esc_html($alert['response']); ?></code>
                 </p>
                 <a href="<?php echo $dismiss_url ?>" class="notice-dismiss" style="text-decoration: none;">
                     <span class="screen-reader-text">Dismiss this notice.</span>

--- a/friendly-captcha/includes/core.php
+++ b/friendly-captcha/includes/core.php
@@ -375,12 +375,32 @@ class FriendlyCaptcha_Plugin
 
     public function show_verification_failed_alert($response)
     {
-        update_option(FriendlyCaptcha_Plugin::$option_verification_failed_alert_name, $response);
+        update_option(FriendlyCaptcha_Plugin::$option_verification_failed_alert_name, array(
+            'response' => $response,
+            'time' => time(),
+        ));
     }
 
     public function get_verification_failed_alert()
     {
-        return get_option(FriendlyCaptcha_Plugin::$option_verification_failed_alert_name);
+        $alert = get_option(FriendlyCaptcha_Plugin::$option_verification_failed_alert_name);
+        if ($alert == false) {
+            return false;
+        }
+
+        // Drop legacy string alerts (pre-timestamp) and start fresh.
+        if (!is_array($alert)) {
+            $this->remove_verification_failed_alert();
+            return false;
+        }
+
+        // Auto-dismiss a week after the most recent failure (timer resets on each).
+        if (isset($alert['time']) && (time() - $alert['time']) > WEEK_IN_SECONDS) {
+            $this->remove_verification_failed_alert();
+            return false;
+        }
+
+        return $alert;
     }
 
     public function remove_verification_failed_alert()

--- a/friendly-captcha/includes/verification.php
+++ b/friendly-captcha/includes/verification.php
@@ -48,7 +48,10 @@ function frcaptcha_v1_verify_captcha_solution($solution, $sitekey, $api_key)
             frcaptcha_log_remote_request($endpoint, $response);
         }
 
-        FriendlyCaptcha_Plugin::$instance->show_verification_failed_alert($raw_response_body);
+        // Only alert admins on config errors (4xx); skip transient 5xx/network.
+        if ($status >= 400 && $status < 500) {
+            FriendlyCaptcha_Plugin::$instance->show_verification_failed_alert($raw_response_body);
+        }
 
         // Better safe than sorry, if the request is non-200 we can not verify the response
         // Either the user's credentials are wrong (e.g. wrong sitekey, api key) or the friendly
@@ -102,8 +105,11 @@ function frcaptcha_v2_verify_captcha_solution($solution, $sitekey, $api_key, $fr
             );
         }
 
-        $raw_response = json_encode($result->response);
-        FriendlyCaptcha_Plugin::$instance->show_verification_failed_alert($raw_response);
+        // Only alert admins on config errors; skip transient request/decode errors.
+        if ($result->isClientError()) {
+            $raw_response = json_encode($result->response);
+            FriendlyCaptcha_Plugin::$instance->show_verification_failed_alert($raw_response);
+        }
 
         // Better safe than sorry, when we can not verify the response
         // Either the user's credentials are wrong (e.g. wrong sitekey, api key) or the friendly


### PR DESCRIPTION
Previously the alert was shown for any verification errors which also caused it to appear for temporary network outages or things like that. Now we only alert on configuration errors (e.g. invalid api key), show the time the error last occurred, and auto dismiss after a week.

This should hopefully reduce the number of support requests we get because of this alert.