### PR TITLE
Fix security review issues

### DIFF
--- a/friendly-captcha/includes/admin.php
+++ b/friendly-captcha/includes/admin.php
@@ -58,8 +58,19 @@ if (is_admin()) {
         add_action('admin_notices', 'frcaptcha_admin_notice__not_configured');
     }
 
-    if (isset($_GET['frcaptcha-verification-failed-dismissed'])) {
-        FriendlyCaptcha_Plugin::$instance->remove_verification_failed_alert();
+    // Deferred to admin_init so pluggable functions (current_user_can) are loaded
+    // and the handler only runs on real admin requests, not admin-ajax.
+    add_action('admin_init', 'frcaptcha_maybe_dismiss_verification_failed_alert');
+    function frcaptcha_maybe_dismiss_verification_failed_alert()
+    {
+        if (
+            isset($_GET['frcaptcha-verification-failed-dismissed']) &&
+            current_user_can('manage_options') &&
+            isset($_GET['_wpnonce']) &&
+            wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['_wpnonce'])), 'frcaptcha-dismiss-verification-failed')
+        ) {
+            FriendlyCaptcha_Plugin::$instance->remove_verification_failed_alert();
+        }
     }
 
     if (FriendlyCaptcha_Plugin::$instance->get_verification_failed_alert() != false) {
@@ -76,7 +87,10 @@ if (is_admin()) {
                 get_admin_url() . 'options-general.php'
             ));
 
-            $dismiss_url = esc_url(add_query_arg('frcaptcha-verification-failed-dismissed', '1'));
+            $dismiss_url = esc_url(wp_nonce_url(
+                add_query_arg('frcaptcha-verification-failed-dismissed', '1'),
+                'frcaptcha-dismiss-verification-failed'
+            ));
 
         ?>
             <div class="notice notice-error is-dismissible">

--- a/friendly-captcha/includes/verification.php
+++ b/friendly-captcha/includes/verification.php
@@ -53,7 +53,8 @@ function frcaptcha_v1_verify_captcha_solution($solution, $sitekey, $api_key)
             FriendlyCaptcha_Plugin::$instance->show_verification_failed_alert($raw_response_body);
         }
 
-        // Better safe than sorry, if the request is non-200 we can not verify the response
+        // Fail open (intentional): if the request is non-200 we can not verify the response,
+        // so we accept it rather than lock legitimate users out of every protected form.
         // Either the user's credentials are wrong (e.g. wrong sitekey, api key) or the friendly
         // captcha servers are unresponsive.
 
@@ -111,7 +112,8 @@ function frcaptcha_v2_verify_captcha_solution($solution, $sitekey, $api_key, $fr
             FriendlyCaptcha_Plugin::$instance->show_verification_failed_alert($raw_response);
         }
 
-        // Better safe than sorry, when we can not verify the response
+        // Fail open (intentional): when we can not verify the response we accept it rather
+        // than lock legitimate users out of every protected form.
         // Either the user's credentials are wrong (e.g. wrong sitekey, api key) or the friendly
         // captcha servers are unresponsive.
 


### PR DESCRIPTION
Unauthenticated admin-context requests (admin-ajax.php) could delete the verification-failed alert option via ?frcaptcha-verification-failed-dismissed=1. Require manage_options + verified nonce; dismiss link now carries nonce.

Also clarify intentional fail-open in verify comments.