### PR TITLE
Fix login with Wordfence 9.0.0 2FA/passkeys

### DIFF
--- a/friendly-captcha/friendly-captcha.php
+++ b/friendly-captcha/friendly-captcha.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Friendly Captcha for WordPress
  * Description: Protect WordPress website forms from spam and abuse with Friendly Captcha, a privacy-first anti-bot solution.
- * Version: 1.17.2
+ * Version: 1.17.3
  * Requires at least: 5.0
  * Requires PHP: 7.3
  * Author: Friendly Captcha GmbH
@@ -19,7 +19,7 @@ if (!defined('WPINC')) {
 	die;
 }
 
-define('FRIENDLY_CAPTCHA_VERSION', '1.17.2');
+define('FRIENDLY_CAPTCHA_VERSION', '1.17.3');
 define('FRIENDLY_CAPTCHA_FRIENDLY_CHALLENGE_VERSION', '0.9.19');
 define('FRIENDLY_CAPTCHA_FRIENDLY_CAPTCHA_SDK_VERSION', '0.1.25');
 define('FRIENDLY_CAPTCHA_SUPPORTED_LANGUAGES', [

--- a/friendly-captcha/modules/wordpress/wordpress_login.php
+++ b/friendly-captcha/modules/wordpress/wordpress_login.php
@@ -17,6 +17,9 @@ function frcaptcha_wp_login_show_widget()
     frcaptcha_enqueue_widget_scripts();
 }
 
+// How long a verified solution may be replayed by a second authentication request for the same user.
+const FRCAPTCHA_LOGIN_REPLAY_TTL = 60;
+
 add_filter('wp_authenticate_user', 'frcaptcha_wp_login_validate', 20, 2);
 
 function frcaptcha_wp_login_validate($user, $password)
@@ -25,7 +28,8 @@ function frcaptcha_wp_login_validate($user, $password)
         return $user;
     }
 
-    // When 2FA is configured using Wordfence, the filter is run twice. We want to skip the second run.
+    // When 2FA is configured using Wordfence before 9.0.0, the filter is run twice. We want to skip the second run.
+    // Wordfence 9.0.0 dropped this constant without a replacement, see frcaptcha_claim_replayed_login_solution.
     // See https://github.com/wordpress-premium/wordfence/blob/master/modules/login-security/classes/controller/wordfencels.php#L568
     $is2FA = (defined('WORDFENCE_LS_AUTHENTICATION_CHECK') && WORDFENCE_LS_AUTHENTICATION_CHECK);
     if ($is2FA) {
@@ -48,13 +52,61 @@ function frcaptcha_wp_login_validate($user, $password)
         return new WP_Error("frcaptcha-empty-error", $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message() . __(" (captcha missing)", "frcaptcha"));
     }
 
+    if (frcaptcha_claim_replayed_login_solution($solution, $user)) {
+        return $user;
+    }
+
     $verification = frcaptcha_verify_captcha_solution($solution, $plugin->get_sitekey(), $plugin->get_api_key());
 
     if (!$verification["success"]) {
         return new WP_Error("frcaptcha-solution-error", $errorPrefix . FriendlyCaptcha_Plugin::default_error_user_message());
     }
 
+    frcaptcha_remember_login_solution($solution, $user);
+
     return $user;
+}
+
+/**
+ * Wordfence 9.0.0 and later authenticate twice for a single login: an admin-ajax preflight
+ * (action=wordfence_ls_authenticate) followed by the real wp-login.php POST. Both carry the same
+ * solution, and the siteverify API rejects the second as response_duplicate.
+ *
+ * To stay compatible we allow a verified solution to be replayed once, by the same user, within a
+ * short window. Only a hash of the solution is stored so that a SQL injection elsewhere on the site
+ * cannot yield a replayable solution.
+ */
+function frcaptcha_login_replay_key($solution)
+{
+    return 'frcaptcha_login_' . hash('sha256', $solution);
+}
+
+function frcaptcha_remember_login_solution($solution, $user)
+{
+    if (!($user instanceof WP_User)) {
+        return;
+    }
+
+    set_transient(frcaptcha_login_replay_key($solution), (int) $user->ID, FRCAPTCHA_LOGIN_REPLAY_TTL);
+}
+
+function frcaptcha_claim_replayed_login_solution($solution, $user)
+{
+    if (!($user instanceof WP_User)) {
+        return false;
+    }
+
+    $key = frcaptcha_login_replay_key($solution);
+    $rememberedUserId = get_transient($key);
+
+    if ($rememberedUserId === false || (int) $rememberedUserId !== (int) $user->ID) {
+        return false;
+    }
+
+    // A solution is replayable exactly once.
+    delete_transient($key);
+
+    return true;
 }
 
 

--- a/friendly-captcha/readme.txt
+++ b/friendly-captcha/readme.txt
@@ -4,7 +4,7 @@ Tags: captcha, antispam, spam, contact form, recaptcha, friendly-captcha, block 
 Requires at least: 5.0
 Tested up to: 6.8
 Requires PHP: 7.3
-Stable tag: 1.17.2
+Stable tag: 1.17.3
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -119,6 +119,11 @@ If you see an integration that's missing, please [open a pull request](https://g
 However, you may wish to email the authors of plugins you'd like to support Friendly Captcha: it will usually take them only an hour or two to add native support if they choose to do so. This will simplify your use of Friendly Captcha, and is the best solution in the long run.
 
 == Changelog ==
+
+= 1.17.3 =
+
+* Fix login failing with "Anti-robot verification failed" when Wordfence 9.0.0 or later is active with 2FA or passkeys enabled
+* Require permissions and a nonce to dismiss the admin verification-failed notice
 
 = 1.17.2 =
 


### PR DESCRIPTION
Wordfence 9.0.0 dropped WORDFENCE_LS_AUTHENTICATION_CHECK, which we used to skip its second authentication pass. It now authenticates twice per login (an admin-ajax preflight, then the real wp-login.php POST), both carrying the same solution, so siteverify rejects the second as response_duplicate and login fails with "Anti-robot verification failed". Passkey login is unaffected because it never goes through wp_authenticate_user.

A verified solution can now be replayed once, by the same user, within 60s. Only a hash of it is stored so SQLi elsewhere can't yield a replayable solution. Kept the old constant check for Wordfence < 9.0.0. This is the workaround Wordfence suggested when they reported it.

Also bumps to 1.17.3. The changelog covers the already merged security fix from #172, which hasn't shipped yet.

closes #174